### PR TITLE
feat: История движения — экран #4

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,14 +1,44 @@
+import { useState } from 'react'
 import StockPage from './pages/StockPage'
+import HistoryPage from './pages/HistoryPage'
+
+const TABS = [
+  { id: 'stock', label: 'Остатки' },
+  { id: 'history', label: 'История' },
+]
+
+const PAGE_TITLES = {
+  stock: 'Остатки',
+  history: 'История движения',
+}
 
 export default function App() {
+  const [tab, setTab] = useState('stock')
+
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 flex flex-col">
       <header className="bg-green-600 text-white px-4 py-3 shadow sticky top-0 z-10">
-        <h1 className="text-lg font-semibold">Остатки</h1>
+        <h1 className="text-lg font-semibold">{PAGE_TITLES[tab]}</h1>
       </header>
-      <main className="px-4 py-4">
-        <StockPage />
+      <main className="px-4 py-4 flex-1">
+        {tab === 'stock' && <StockPage />}
+        {tab === 'history' && <HistoryPage />}
       </main>
+      <nav className="sticky bottom-0 bg-white border-t border-gray-200 flex">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            onClick={() => setTab(t.id)}
+            className={`flex-1 py-3 text-sm font-medium ${
+              tab === t.id
+                ? 'text-green-600 border-t-2 border-green-600'
+                : 'text-gray-500'
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </nav>
     </div>
   )
 }

--- a/src/hooks/useMovementHistory.js
+++ b/src/hooks/useMovementHistory.js
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '../lib/supabase'
+
+export function useMovementHistory(flowerId = null) {
+  const [movements, setMovements] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  async function fetchData() {
+    setLoading(true)
+    setError(null)
+    try {
+      let query = supabase
+        .from('movements')
+        .select('*, flowers(name)')
+        .order('created_at', { ascending: false })
+        .limit(100)
+
+      if (flowerId) {
+        query = query.eq('flower_id', flowerId)
+      }
+
+      const { data, error: err } = await query
+      if (err) throw err
+      setMovements(data || [])
+    } catch (err) {
+      setError(err.message || 'Ошибка загрузки')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchData()
+  }, [flowerId])
+
+  return { movements, loading, error, refresh: fetchData }
+}

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -1,0 +1,93 @@
+import { useState } from 'react'
+import { useFlowerStock } from '../hooks/useFlowerStock'
+import { useMovementHistory } from '../hooks/useMovementHistory'
+
+const TYPE_STYLES = {
+  поставка: 'bg-green-100 text-green-700',
+  резерв: 'bg-blue-100 text-blue-700',
+  выдача: 'bg-gray-100 text-gray-600',
+  списание: 'bg-red-100 text-red-700',
+}
+
+const TYPE_SIGN = {
+  поставка: '+',
+  резерв: '-',
+  выдача: '-',
+  списание: '-',
+}
+
+function formatDate(dateStr) {
+  return new Date(dateStr).toLocaleDateString('ru-RU', {
+    day: '2-digit',
+    month: '2-digit',
+    year: '2-digit',
+  })
+}
+
+export default function HistoryPage() {
+  const [flowerId, setFlowerId] = useState('')
+  const { flowers } = useFlowerStock()
+  const { movements, loading, error, refresh } = useMovementHistory(flowerId || null)
+
+  return (
+    <div>
+      <select
+        value={flowerId}
+        onChange={(e) => setFlowerId(e.target.value)}
+        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white mb-4"
+      >
+        <option value="">Все цветы</option>
+        {flowers.map((f) => (
+          <option key={f.flower_id} value={f.flower_id}>
+            {f.name}
+          </option>
+        ))}
+      </select>
+
+      {loading && (
+        <p className="text-center text-gray-400 text-sm mt-6">Загрузка...</p>
+      )}
+
+      {error && (
+        <div className="text-center mt-6">
+          <p className="text-red-500 text-sm mb-2">{error}</p>
+          <button onClick={refresh} className="text-sm text-green-600 underline">
+            Повторить
+          </button>
+        </div>
+      )}
+
+      {!loading && !error && movements.length === 0 && (
+        <p className="text-center text-gray-400 text-sm mt-6">Движений нет</p>
+      )}
+
+      {!loading && !error && movements.length > 0 && (
+        <ul className="space-y-2">
+          {movements.map((m) => {
+            const typeStyle = TYPE_STYLES[m.movement_type] ?? 'bg-gray-100 text-gray-600'
+            const sign = TYPE_SIGN[m.movement_type] ?? ''
+            return (
+              <li
+                key={m.id}
+                className="bg-white rounded-lg px-4 py-3 shadow-sm flex items-center justify-between"
+              >
+                <div>
+                  <p className="text-sm font-medium text-gray-800">{m.flowers?.name}</p>
+                  <p className="text-xs text-gray-400 mt-0.5">{formatDate(m.created_at)}</p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${typeStyle}`}>
+                    {m.movement_type}
+                  </span>
+                  <span className="text-sm font-semibold text-gray-700">
+                    {sign}{Math.abs(m.quantity)}
+                  </span>
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/tests/HistoryPage.test.jsx
+++ b/src/tests/HistoryPage.test.jsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import HistoryPage from '../pages/HistoryPage'
+
+vi.mock('../hooks/useFlowerStock', () => ({
+  useFlowerStock: vi.fn(),
+}))
+vi.mock('../hooks/useMovementHistory', () => ({
+  useMovementHistory: vi.fn(),
+}))
+
+import { useFlowerStock } from '../hooks/useFlowerStock'
+import { useMovementHistory } from '../hooks/useMovementHistory'
+
+const FLOWERS = [
+  { flower_id: '1', name: 'Роза', total: 10, reserved: 2, available: 8, stale: false },
+  { flower_id: '2', name: 'Тюльпан', total: 5, reserved: 0, available: 5, stale: false },
+]
+
+describe('HistoryPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useFlowerStock.mockReturnValue({ flowers: FLOWERS, loading: false, error: null })
+    useMovementHistory.mockReturnValue({ movements: [], loading: false, error: null, refresh: vi.fn() })
+  })
+
+  it('показывает фильтр со списком цветов', () => {
+    render(<HistoryPage />)
+    expect(screen.getByText('Все цветы')).toBeDefined()
+    expect(screen.getByText('Роза')).toBeDefined()
+    expect(screen.getByText('Тюльпан')).toBeDefined()
+  })
+
+  it('показывает пустое состояние', () => {
+    render(<HistoryPage />)
+    expect(screen.getByText('Движений нет')).toBeDefined()
+  })
+
+  it('показывает загрузку', () => {
+    useMovementHistory.mockReturnValue({ movements: [], loading: true, error: null, refresh: vi.fn() })
+    render(<HistoryPage />)
+    expect(screen.getByText('Загрузка...')).toBeDefined()
+  })
+
+  it('показывает ошибку и кнопку повтора', () => {
+    const refresh = vi.fn()
+    useMovementHistory.mockReturnValue({ movements: [], loading: false, error: 'Ошибка сети', refresh })
+    render(<HistoryPage />)
+    expect(screen.getByText('Ошибка сети')).toBeDefined()
+    fireEvent.click(screen.getByText('Повторить'))
+    expect(refresh).toHaveBeenCalledOnce()
+  })
+
+  it('отображает строки движений', () => {
+    useMovementHistory.mockReturnValue({
+      movements: [
+        {
+          id: '1',
+          flower_id: '1',
+          flowers: { name: 'Роза' },
+          movement_type: 'поставка',
+          quantity: 20,
+          created_at: '2026-03-15T10:00:00Z',
+        },
+        {
+          id: '2',
+          flower_id: '1',
+          flowers: { name: 'Роза' },
+          movement_type: 'резерв',
+          quantity: 5,
+          created_at: '2026-03-14T09:00:00Z',
+        },
+      ],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    })
+    render(<HistoryPage />)
+    // 2 строки движений + 1 опция в фильтре = 3
+    expect(screen.getAllByText('Роза')).toHaveLength(3)
+    expect(screen.getByText('поставка')).toBeDefined()
+    expect(screen.getByText('резерв')).toBeDefined()
+    expect(screen.getByText('+20')).toBeDefined()
+    expect(screen.getByText('-5')).toBeDefined()
+  })
+
+  it('передаёт flower_id в хук при выборе фильтра', () => {
+    render(<HistoryPage />)
+    const select = screen.getByRole('combobox')
+    fireEvent.change(select, { target: { value: '1' } })
+    expect(useMovementHistory).toHaveBeenLastCalledWith('1')
+  })
+})


### PR DESCRIPTION
- Хук useMovementHistory — запрос movements с join flowers, фильтр по flower_id
- Страница HistoryPage — список движений с фильтром по цветку
- App.jsx — нижняя навигация (Остатки / История)
- 6 тестов HistoryPage (загрузка, ошибка, пустой список, строки, фильтр)

https://claude.ai/code/session_01LcJUuNQvfhF1CShntnhSQs