### PR TITLE
feat: экран Новый заказ (#8)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,9 +4,11 @@ import HistoryPage from './pages/HistoryPage'
 import OrdersPage from './pages/OrdersPage'
 import SuppliersPage from './pages/SuppliersPage'
 import DeliveryPage from './pages/DeliveryPage'
+import NewOrderPage from './pages/NewOrderPage'
 
 const TABS = [
   { id: 'stock', label: 'Остатки' },
+  { id: 'neworder', label: 'Заказ' },
   { id: 'delivery', label: 'Поставка' },
   { id: 'orders', label: 'Заказы' },
   { id: 'history', label: 'История' },
@@ -15,6 +17,7 @@ const TABS = [
 
 const PAGE_TITLES = {
   stock: 'Остатки',
+  neworder: 'Новый заказ',
   delivery: 'Новая поставка',
   orders: 'Заказы',
   history: 'История движения',
@@ -31,6 +34,7 @@ export default function App() {
       </header>
       <main className="px-4 py-4 flex-1">
         {tab === 'stock' && <StockPage />}
+        {tab === 'neworder' && <NewOrderPage />}
         {tab === 'delivery' && <DeliveryPage />}
         {tab === 'orders' && <OrdersPage />}
         {tab === 'history' && <HistoryPage />}

--- a/src/hooks/useNewOrder.js
+++ b/src/hooks/useNewOrder.js
@@ -1,0 +1,38 @@
+import { supabase } from '../lib/supabase'
+
+export function useNewOrder() {
+  async function saveOrder({ clientName, clientPhone, readyAt, deliveryType, address, items }) {
+    const { data: order, error: orderErr } = await supabase
+      .from('orders')
+      .insert({
+        client_name: clientName,
+        client_phone: clientPhone || null,
+        delivery_type: deliveryType,
+        delivery_address: deliveryType === 'доставка' ? address : null,
+        ready_at: readyAt,
+        status: 'новый',
+      })
+      .select('id')
+      .single()
+    if (orderErr) throw orderErr
+
+    for (const item of items) {
+      const { error: itemErr } = await supabase
+        .from('order_items')
+        .insert({ order_id: order.id, flower_id: item.flowerId, quantity: item.quantity })
+      if (itemErr) throw itemErr
+
+      const { error: movErr } = await supabase
+        .from('movements')
+        .insert({
+          flower_id: item.flowerId,
+          order_id: order.id,
+          movement_type: 'резерв',
+          quantity: item.quantity,
+        })
+      if (movErr) throw movErr
+    }
+  }
+
+  return { saveOrder }
+}

--- a/src/pages/NewOrderPage.jsx
+++ b/src/pages/NewOrderPage.jsx
@@ -1,0 +1,213 @@
+import { useState } from 'react'
+import { useFlowerStock } from '../hooks/useFlowerStock'
+import { useNewOrder } from '../hooks/useNewOrder'
+
+function newItem() {
+  return { id: Date.now() + Math.random(), flowerId: '', quantity: '' }
+}
+
+export default function NewOrderPage() {
+  const { flowers, loading } = useFlowerStock()
+  const { saveOrder } = useNewOrder()
+
+  const [clientName, setClientName] = useState('')
+  const [clientPhone, setClientPhone] = useState('')
+  const [readyAt, setReadyAt] = useState('')
+  const [deliveryType, setDeliveryType] = useState('самовывоз')
+  const [address, setAddress] = useState('')
+  const [items, setItems] = useState([newItem()])
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState(null)
+  const [success, setSuccess] = useState(false)
+
+  const availableFlowers = (flowers || []).filter((f) => f.available > 0)
+
+  function updateItem(id, patch) {
+    setItems((prev) => prev.map((it) => (it.id === id ? { ...it, ...patch } : it)))
+  }
+
+  function addItem() {
+    setItems((prev) => [...prev, newItem()])
+  }
+
+  function removeItem(id) {
+    setItems((prev) => prev.filter((it) => it.id !== id))
+  }
+
+  function maxQty(flowerId) {
+    const f = availableFlowers.find((f) => f.flower_id === flowerId)
+    return f ? f.available : 0
+  }
+
+  const isValid =
+    clientName.trim() &&
+    readyAt &&
+    items.length > 0 &&
+    items.every(
+      (it) =>
+        it.flowerId &&
+        Number(it.quantity) > 0 &&
+        Number(it.quantity) <= maxQty(it.flowerId)
+    ) &&
+    (deliveryType === 'самовывоз' || address.trim())
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setError(null)
+    setSuccess(false)
+    setSaving(true)
+    try {
+      await saveOrder({
+        clientName: clientName.trim(),
+        clientPhone: clientPhone.trim() || null,
+        readyAt,
+        deliveryType,
+        address: address.trim(),
+        items: items.map((it) => ({ flowerId: it.flowerId, quantity: Number(it.quantity) })),
+      })
+      setSuccess(true)
+      setClientName('')
+      setClientPhone('')
+      setReadyAt('')
+      setDeliveryType('самовывоз')
+      setAddress('')
+      setItems([newItem()])
+    } catch (err) {
+      setError(err.message || 'Ошибка сохранения')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return <p className="text-center text-gray-400 mt-10 text-sm">Загрузка...</p>
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {success && (
+        <p className="text-green-600 text-sm text-center bg-green-50 rounded-xl py-2">
+          Заказ сохранён
+        </p>
+      )}
+      {error && <p className="text-red-500 text-sm text-center">{error}</p>}
+
+      <div className="bg-white rounded-xl p-4 shadow-sm space-y-3">
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">Имя клиента</label>
+          <input
+            type="text"
+            value={clientName}
+            onChange={(e) => setClientName(e.target.value)}
+            placeholder="Введите имя"
+            required
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">Телефон</label>
+          <input
+            type="tel"
+            value={clientPhone}
+            onChange={(e) => setClientPhone(e.target.value)}
+            placeholder="+7 999 000 00 00"
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">Дата готовности</label>
+          <input
+            type="date"
+            value={readyAt}
+            onChange={(e) => setReadyAt(e.target.value)}
+            required
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">Тип получения</label>
+          <select
+            value={deliveryType}
+            onChange={(e) => setDeliveryType(e.target.value)}
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+          >
+            <option value="самовывоз">Самовывоз</option>
+            <option value="доставка">Доставка</option>
+          </select>
+        </div>
+        {deliveryType === 'доставка' && (
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">Адрес доставки</label>
+            <input
+              type="text"
+              value={address}
+              onChange={(e) => setAddress(e.target.value)}
+              placeholder="Введите адрес"
+              required
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+            />
+          </div>
+        )}
+      </div>
+
+      {items.map((item, idx) => {
+        const max = maxQty(item.flowerId)
+        return (
+          <div key={item.id} className="bg-white rounded-xl p-4 shadow-sm space-y-3">
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-gray-500 font-medium">Позиция {idx + 1}</span>
+              {items.length > 1 && (
+                <button
+                  type="button"
+                  onClick={() => removeItem(item.id)}
+                  className="text-xs text-red-400"
+                >
+                  Удалить
+                </button>
+              )}
+            </div>
+            <select
+              value={item.flowerId}
+              onChange={(e) => updateItem(item.id, { flowerId: e.target.value, quantity: '' })}
+              required
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+            >
+              <option value="">Выберите цветок</option>
+              {availableFlowers.map((f) => (
+                <option key={f.flower_id} value={f.flower_id}>
+                  {f.name} (свободно: {f.available})
+                </option>
+              ))}
+            </select>
+            <input
+              type="number"
+              min="1"
+              max={item.flowerId ? max : undefined}
+              placeholder="Количество (шт)"
+              value={item.quantity}
+              onChange={(e) => updateItem(item.id, { quantity: e.target.value })}
+              required
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+            />
+          </div>
+        )
+      })}
+
+      <button
+        type="button"
+        onClick={addItem}
+        className="w-full border border-green-600 text-green-600 text-sm py-2 rounded-xl"
+      >
+        + Добавить цветок
+      </button>
+
+      <button
+        type="submit"
+        disabled={saving || !isValid}
+        className="w-full bg-green-600 text-white text-sm py-3 rounded-xl disabled:opacity-50"
+      >
+        {saving ? 'Сохранение...' : 'Сохранить заказ'}
+      </button>
+    </form>
+  )
+}

--- a/src/tests/NewOrderPage.test.jsx
+++ b/src/tests/NewOrderPage.test.jsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import NewOrderPage from '../pages/NewOrderPage'
+
+vi.mock('../hooks/useFlowerStock', () => ({ useFlowerStock: vi.fn() }))
+vi.mock('../hooks/useNewOrder', () => ({ useNewOrder: vi.fn() }))
+
+import { useFlowerStock } from '../hooks/useFlowerStock'
+import { useNewOrder } from '../hooks/useNewOrder'
+
+const mockFlowers = [
+  { flower_id: '1', name: 'Роза', total: 10, reserved: 2, available: 8, stale: false },
+  { flower_id: '2', name: 'Тюльпан', total: 5, reserved: 5, available: 0, stale: false },
+]
+
+function setup(saveOrderOverride) {
+  const saveOrder = saveOrderOverride ?? vi.fn().mockResolvedValue(undefined)
+  useFlowerStock.mockReturnValue({ flowers: mockFlowers, loading: false, error: null, refresh: vi.fn() })
+  useNewOrder.mockReturnValue({ saveOrder })
+  return { saveOrder }
+}
+
+function fillBaseForm() {
+  fireEvent.change(screen.getByPlaceholderText(/введите имя/i), { target: { value: 'Анна' } })
+  const dateInput = document.querySelector('input[type="date"]')
+  fireEvent.change(dateInput, { target: { value: '2026-03-20' } })
+}
+
+describe('NewOrderPage', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('показывает загрузку пока данные не загружены', () => {
+    useFlowerStock.mockReturnValue({ flowers: [], loading: true, error: null, refresh: vi.fn() })
+    useNewOrder.mockReturnValue({ saveOrder: vi.fn() })
+    render(<NewOrderPage />)
+    expect(screen.getByText(/загрузка/i)).toBeDefined()
+  })
+
+  it('рендерит поля формы', () => {
+    setup()
+    render(<NewOrderPage />)
+    expect(screen.getByPlaceholderText(/введите имя/i)).toBeDefined()
+    expect(screen.getByPlaceholderText(/\+7/i)).toBeDefined()
+    expect(document.querySelector('input[type="date"]')).toBeDefined()
+    expect(screen.getByText(/тип получения/i)).toBeDefined()
+  })
+
+  it('не показывает поле адреса при самовывозе', () => {
+    setup()
+    render(<NewOrderPage />)
+    expect(screen.queryByPlaceholderText(/введите адрес/i)).toBeNull()
+  })
+
+  it('показывает поле адреса при выборе доставки', () => {
+    setup()
+    render(<NewOrderPage />)
+    const selects = screen.getAllByRole('combobox')
+    const deliverySelect = selects.find((s) => s.value === 'самовывоз')
+    fireEvent.change(deliverySelect, { target: { value: 'доставка' } })
+    expect(screen.getByPlaceholderText(/введите адрес/i)).toBeDefined()
+  })
+
+  it('скрывает поле адреса при переключении обратно на самовывоз', () => {
+    setup()
+    render(<NewOrderPage />)
+    const selects = screen.getAllByRole('combobox')
+    const deliverySelect = selects.find((s) => s.value === 'самовывоз')
+    fireEvent.change(deliverySelect, { target: { value: 'доставка' } })
+    fireEvent.change(deliverySelect, { target: { value: 'самовывоз' } })
+    expect(screen.queryByPlaceholderText(/введите адрес/i)).toBeNull()
+  })
+
+  it('показывает только цветы с доступными остатками', () => {
+    setup()
+    render(<NewOrderPage />)
+    expect(screen.getByText(/роза/i)).toBeDefined()
+    expect(screen.queryByText(/тюльпан/i)).toBeNull()
+  })
+
+  it('добавляет новую позицию по кнопке', () => {
+    setup()
+    render(<NewOrderPage />)
+    expect(screen.getAllByText(/позиция/i)).toHaveLength(1)
+    fireEvent.click(screen.getByText(/добавить цветок/i))
+    expect(screen.getAllByText(/позиция/i)).toHaveLength(2)
+  })
+
+  it('удаляет позицию по кнопке', () => {
+    setup()
+    render(<NewOrderPage />)
+    fireEvent.click(screen.getByText(/добавить цветок/i))
+    expect(screen.getAllByText(/позиция/i)).toHaveLength(2)
+    fireEvent.click(screen.getAllByText('Удалить')[0])
+    expect(screen.getAllByText(/позиция/i)).toHaveLength(1)
+  })
+
+  it('кнопка «Сохранить» заблокирована при пустой форме', () => {
+    setup()
+    render(<NewOrderPage />)
+    const btn = screen.getByRole('button', { name: /сохранить заказ/i })
+    expect(btn.disabled).toBe(true)
+  })
+
+  it('вызывает saveOrder с корректными данными', async () => {
+    const { saveOrder } = setup()
+    render(<NewOrderPage />)
+    fillBaseForm()
+    const flowerSelects = screen.getAllByRole('combobox')
+    const flowerSelect = flowerSelects[flowerSelects.length - 1]
+    fireEvent.change(flowerSelect, { target: { value: '1' } })
+    fireEvent.change(screen.getByPlaceholderText(/количество/i), { target: { value: '3' } })
+    fireEvent.click(screen.getByRole('button', { name: /сохранить заказ/i }))
+    await waitFor(() =>
+      expect(saveOrder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clientName: 'Анна',
+          deliveryType: 'самовывоз',
+          items: expect.arrayContaining([
+            expect.objectContaining({ flowerId: '1', quantity: 3 }),
+          ]),
+        })
+      )
+    )
+  })
+
+  it('показывает сообщение об успехе после сохранения', async () => {
+    const { saveOrder } = setup()
+    render(<NewOrderPage />)
+    fillBaseForm()
+    const flowerSelects = screen.getAllByRole('combobox')
+    const flowerSelect = flowerSelects[flowerSelects.length - 1]
+    fireEvent.change(flowerSelect, { target: { value: '1' } })
+    fireEvent.change(screen.getByPlaceholderText(/количество/i), { target: { value: '3' } })
+    fireEvent.click(screen.getByRole('button', { name: /сохранить заказ/i }))
+    await waitFor(() => expect(screen.getByText(/заказ сохранён/i)).toBeDefined())
+  })
+
+  it('показывает ошибку при неудачном сохранении', async () => {
+    setup(vi.fn().mockRejectedValue(new Error('Нет сети')))
+    render(<NewOrderPage />)
+    fillBaseForm()
+    const flowerSelects = screen.getAllByRole('combobox')
+    const flowerSelect = flowerSelects[flowerSelects.length - 1]
+    fireEvent.change(flowerSelect, { target: { value: '1' } })
+    fireEvent.change(screen.getByPlaceholderText(/количество/i), { target: { value: '3' } })
+    fireEvent.click(screen.getByRole('button', { name: /сохранить заказ/i }))
+    await waitFor(() => expect(screen.getByText('Нет сети')).toBeDefined())
+  })
+})


### PR DESCRIPTION
- Хук useNewOrder: создаёт order, order_items и movement(резерв)
- NewOrderPage: форма с валидацией, адрес только при доставке, список цветков из свободных остатков
- Добавлен таб «Заказ» в навигацию App.jsx
- 12 тестов Vitest, все зелёные (64/64)

https://claude.ai/code/session_01LcJUuNQvfhF1CShntnhSQs