### PR TITLE
fix: delivery_address + убрать дублирующую вкладку

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,6 @@ import NewOrderPage from './pages/NewOrderPage'
 
 const TABS = [
   { id: 'stock', label: 'Остатки' },
-  { id: 'neworder', label: 'Заказ' },
   { id: 'delivery', label: 'Поставка' },
   { id: 'orders', label: 'Заказы' },
   { id: 'history', label: 'История' },
@@ -34,9 +33,9 @@ export default function App() {
       </header>
       <main className="px-4 py-4 flex-1">
         {tab === 'stock' && <StockPage />}
-        {tab === 'neworder' && <NewOrderPage />}
+        {tab === 'neworder' && <NewOrderPage onBack={() => setTab('orders')} />}
         {tab === 'delivery' && <DeliveryPage />}
-        {tab === 'orders' && <OrdersPage />}
+        {tab === 'orders' && <OrdersPage onNewOrder={() => setTab('neworder')} />}
         {tab === 'history' && <HistoryPage />}
         {tab === 'suppliers' && <SuppliersPage />}
       </main>

--- a/src/components/OrderCard.jsx
+++ b/src/components/OrderCard.jsx
@@ -12,7 +12,7 @@ function formatDate(dateStr) {
 }
 
 export default function OrderCard({ order }) {
-  const { client_name, client_phone, delivery_type, status, ready_at, address, order_items = [] } = order
+  const { client_name, client_phone, delivery_type, delivery_address, status, ready_at, order_items = [] } = order
   const statusStyle = STATUS_STYLES[status] || 'bg-gray-100 text-gray-600'
   const isDelivery = delivery_type === 'доставка'
 
@@ -39,7 +39,7 @@ export default function OrderCard({ order }) {
       <div className="flex items-center gap-3 text-xs text-gray-400">
         <span>{isDelivery ? '🚚 доставка' : '🏪 самовывоз'}</span>
         {ready_at && <span>к {formatDate(ready_at)}</span>}
-        {isDelivery && address && <span className="truncate">{address}</span>}
+        {isDelivery && delivery_address && <span className="truncate">{delivery_address}</span>}
       </div>
     </div>
   )

--- a/src/hooks/useOrders.js
+++ b/src/hooks/useOrders.js
@@ -19,9 +19,9 @@ export function useOrders() {
           client_name,
           client_phone,
           delivery_type,
+          delivery_address,
           status,
           ready_at,
-          address,
           order_items (
             quantity,
             flowers ( name )

--- a/src/pages/NewOrderPage.jsx
+++ b/src/pages/NewOrderPage.jsx
@@ -6,7 +6,7 @@ function newItem() {
   return { id: Date.now() + Math.random(), flowerId: '', quantity: '' }
 }
 
-export default function NewOrderPage() {
+export default function NewOrderPage({ onBack }) {
   const { flowers, loading } = useFlowerStock()
   const { saveOrder } = useNewOrder()
 
@@ -72,6 +72,7 @@ export default function NewOrderPage() {
       setDeliveryType('самовывоз')
       setAddress('')
       setItems([newItem()])
+      if (onBack) setTimeout(onBack, 1200)
     } catch (err) {
       setError(err.message || 'Ошибка сохранения')
     } finally {

--- a/src/pages/OrdersPage.jsx
+++ b/src/pages/OrdersPage.jsx
@@ -1,7 +1,7 @@
 import OrderCard from '../components/OrderCard'
 import { useOrders } from '../hooks/useOrders'
 
-export default function OrdersPage() {
+export default function OrdersPage({ onNewOrder }) {
   const { orders, loading, error, refresh } = useOrders()
 
   if (loading) {
@@ -19,19 +19,19 @@ export default function OrdersPage() {
     )
   }
 
-  if (orders.length === 0) {
-    return (
-      <p className="text-center text-gray-400 mt-10 text-sm">
-        Активных заказов нет
-      </p>
-    )
-  }
-
   return (
     <div className="space-y-3">
-      {orders.map((order) => (
-        <OrderCard key={order.id} order={order} />
-      ))}
+      <button
+        onClick={onNewOrder}
+        className="w-full bg-green-600 text-white text-sm py-3 rounded-xl"
+      >
+        + Новый заказ
+      </button>
+      {orders.length === 0 ? (
+        <p className="text-center text-gray-400 mt-6 text-sm">Активных заказов нет</p>
+      ) : (
+        orders.map((order) => <OrderCard key={order.id} order={order} />)
+      )}
     </div>
   )
 }

--- a/src/tests/OrdersPage.test.jsx
+++ b/src/tests/OrdersPage.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import OrdersPage from '../pages/OrdersPage'
 import OrderCard from '../components/OrderCard'
 
@@ -17,7 +17,7 @@ const mockOrders = [
     delivery_type: 'самовывоз',
     status: 'новый',
     ready_at: '2026-03-20',
-    address: null,
+    delivery_address: null,
     order_items: [
       { quantity: 5, flowers: { name: 'Роза' } },
       { quantity: 3, flowers: { name: 'Тюльпан' } },
@@ -30,7 +30,7 @@ const mockOrders = [
     delivery_type: 'доставка',
     status: 'в работе',
     ready_at: '2026-03-21',
-    address: 'ул. Ленина, 5',
+    delivery_address: 'ул. Ленина, 5',
     order_items: [],
   },
 ]
@@ -53,15 +53,23 @@ describe('OrdersPage', () => {
 
   it('показывает сообщение при пустом списке', () => {
     useOrders.mockReturnValue({ orders: [], loading: false, error: null, refresh: vi.fn() })
-    render(<OrdersPage />)
+    render(<OrdersPage onNewOrder={vi.fn()} />)
     expect(screen.getByText(/активных заказов нет/i)).toBeDefined()
   })
 
   it('рендерит карточки заказов', () => {
     useOrders.mockReturnValue({ orders: mockOrders, loading: false, error: null, refresh: vi.fn() })
-    render(<OrdersPage />)
+    render(<OrdersPage onNewOrder={vi.fn()} />)
     expect(screen.getByText('Анна')).toBeDefined()
     expect(screen.getByText('Мария')).toBeDefined()
+  })
+
+  it('вызывает onNewOrder при нажатии кнопки', () => {
+    const onNewOrder = vi.fn()
+    useOrders.mockReturnValue({ orders: [], loading: false, error: null, refresh: vi.fn() })
+    render(<OrdersPage onNewOrder={onNewOrder} />)
+    fireEvent.click(screen.getByText(/новый заказ/i))
+    expect(onNewOrder).toHaveBeenCalledOnce()
   })
 })
 


### PR DESCRIPTION
- useOrders.js: address → delivery_address (баг с несуществующей колонкой)
- OrderCard.jsx: адрес из delivery_address
- OrdersPage: кнопка «+ Новый заказ» вместо отдельной вкладки
- NewOrderPage: автовозврат на Заказы после сохранения
- App.jsx: вкладка «Заказ» убрана из навигации
- Тесты: обновлены под delivery_address и onNewOrder prop

https://claude.ai/code/session_01LcJUuNQvfhF1CShntnhSQs