### PR TITLE
feat: История движений — режим по партии, расширенные теги движений (…

### DIFF
--- a/src/hooks/useBatchDeliveries.js
+++ b/src/hooks/useBatchDeliveries.js
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '../lib/supabase'
+
+export function useBatchDeliveries() {
+  const [deliveries, setDeliveries] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  async function fetchData() {
+    setLoading(true)
+    setError(null)
+    try {
+      const { data, error: err } = await supabase
+        .from('deliveries')
+        .select('id, delivered_at, suppliers(name), delivery_items(id, flower_id, quantity, batch_id, flowers(name))')
+        .eq('status', 'на складе')
+        .order('delivered_at', { ascending: false })
+      if (err) throw err
+      setDeliveries(data || [])
+    } catch (err) {
+      setError(err.message || 'Ошибка загрузки')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchData()
+  }, [])
+
+  return { deliveries, loading, error }
+}

--- a/src/hooks/useMovementHistory.js
+++ b/src/hooks/useMovementHistory.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { supabase } from '../lib/supabase'
 
-export function useMovementHistory(flowerId = null) {
+export function useMovementHistory(flowerId = null, batchIds = null) {
   const [movements, setMovements] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -12,13 +12,12 @@ export function useMovementHistory(flowerId = null) {
     try {
       let query = supabase
         .from('movements')
-        .select('*, flowers(name)')
+        .select('*, flowers(name), orders(client_name, ready_at), defects(defect_type), batches(delivery_items(reception_status, comment))')
         .order('created_at', { ascending: false })
         .limit(100)
 
-      if (flowerId) {
-        query = query.eq('flower_id', flowerId)
-      }
+      if (flowerId) query = query.eq('flower_id', flowerId)
+      if (batchIds && batchIds.length > 0) query = query.in('batch_id', batchIds)
 
       const { data, error: err } = await query
       if (err) throw err
@@ -32,7 +31,7 @@ export function useMovementHistory(flowerId = null) {
 
   useEffect(() => {
     fetchData()
-  }, [flowerId])
+  }, [flowerId, batchIds?.join(',')])
 
   return { movements, loading, error, refresh: fetchData }
 }

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -1,20 +1,7 @@
 import { useState } from 'react'
 import { useFlowerStock } from '../hooks/useFlowerStock'
 import { useMovementHistory } from '../hooks/useMovementHistory'
-
-const TYPE_STYLES = {
-  поставка: 'bg-green-100 text-green-700',
-  резерв: 'bg-blue-100 text-blue-700',
-  выдача: 'bg-gray-100 text-gray-600',
-  списание: 'bg-red-100 text-red-700',
-}
-
-const TYPE_SIGN = {
-  поставка: '+',
-  резерв: '-',
-  выдача: '-',
-  списание: '-',
-}
+import { useBatchDeliveries } from '../hooks/useBatchDeliveries'
 
 function formatDate(dateStr) {
   return new Date(dateStr).toLocaleDateString('ru-RU', {
@@ -24,25 +11,160 @@ function formatDate(dateStr) {
   })
 }
 
+function formatShortDate(dateStr) {
+  if (!dateStr) return ''
+  return new Date(dateStr)
+    .toLocaleDateString('ru-RU', { day: 'numeric', month: 'short' })
+    .replace(/\.$/, '')
+}
+
+function posLabel(n) {
+  if (n === 1) return '1 позиция'
+  if (n >= 2 && n <= 4) return `${n} позиции`
+  return `${n} позиций`
+}
+
+function getMovementDisplay(m) {
+  const deliveryItem = m.batches?.delivery_items?.[0]
+  const isWrongOrder =
+    m.movement_type === 'поставка' && deliveryItem?.reception_status === 'не_тот_заказ'
+
+  if (isWrongOrder) {
+    return {
+      label: 'на складе',
+      tagClass: 'bg-yellow-100 text-yellow-700',
+      sign: '+',
+      extra: deliveryItem.comment ? `⚠️ ${deliveryItem.comment}` : '⚠️ другой цвет',
+    }
+  }
+
+  switch (m.movement_type) {
+    case 'поставка':
+      return { label: 'поставка', tagClass: 'bg-green-100 text-green-700', sign: '+', extra: null }
+    case 'резерв':
+      return {
+        label: 'резерв',
+        tagClass: 'bg-blue-100 text-blue-700',
+        sign: '-',
+        extra: m.orders
+          ? `${m.orders.client_name}, ${formatShortDate(m.orders.ready_at)}`
+          : null,
+      }
+    case 'списание':
+      return { label: 'списание', tagClass: 'bg-red-100 text-red-700', sign: '-', extra: '⚠️ брак' }
+    case 'выдача':
+      return { label: 'выдача', tagClass: 'bg-gray-100 text-gray-600', sign: '-', extra: null }
+    default:
+      return { label: m.movement_type, tagClass: 'bg-gray-100 text-gray-600', sign: '', extra: null }
+  }
+}
+
+function BatchPopup({ delivery, onClose }) {
+  const items = delivery.delivery_items || []
+  return (
+    <div className="fixed inset-0 bg-black/40 z-50 flex items-end" onClick={onClose}>
+      <div
+        className="bg-white w-full rounded-t-2xl p-5 pb-8"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <p className="font-semibold text-gray-800">
+            {formatDate(delivery.delivered_at)} · {delivery.suppliers?.name}
+          </p>
+          <button onClick={onClose} className="text-gray-400 text-lg leading-none">✕</button>
+        </div>
+        <ul className="space-y-2">
+          {items.map((item) => (
+            <li key={item.id} className="flex justify-between text-sm text-gray-700">
+              <span>{item.flowers?.name}</span>
+              <span className="font-medium">{item.quantity} шт</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
 export default function HistoryPage() {
+  const [mode, setMode] = useState('flower')
   const [flowerId, setFlowerId] = useState('')
+  const [selectedDelivery, setSelectedDelivery] = useState(null)
+  const [showPopup, setShowPopup] = useState(false)
+
   const { flowers } = useFlowerStock()
-  const { movements, loading, error, refresh } = useMovementHistory(flowerId || null)
+  const { deliveries } = useBatchDeliveries()
+
+  const batchIds =
+    selectedDelivery?.delivery_items
+      ?.filter((di) => di.batch_id)
+      .map((di) => di.batch_id) || null
+
+  const { movements, loading, error, refresh } = useMovementHistory(
+    mode === 'flower' ? flowerId || null : null,
+    mode === 'batch' ? batchIds : null
+  )
+
+  function handleDeliverySelect(deliveryId) {
+    const d = deliveries.find((d) => d.id === deliveryId)
+    setSelectedDelivery(d || null)
+    if (d) setShowPopup(true)
+  }
 
   return (
     <div>
-      <select
-        value={flowerId}
-        onChange={(e) => setFlowerId(e.target.value)}
-        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white mb-4"
-      >
-        <option value="">Все цветы</option>
-        {flowers.map((f) => (
-          <option key={f.flower_id} value={f.flower_id}>
-            {f.name}
-          </option>
-        ))}
-      </select>
+      <div className="flex rounded-lg overflow-hidden border border-gray-200 mb-4">
+        <button
+          className={`flex-1 py-2 text-sm font-medium transition-colors ${
+            mode === 'flower' ? 'bg-green-600 text-white' : 'bg-white text-gray-600'
+          }`}
+          onClick={() => { setMode('flower'); setSelectedDelivery(null) }}
+        >
+          По цветку
+        </button>
+        <button
+          className={`flex-1 py-2 text-sm font-medium transition-colors ${
+            mode === 'batch' ? 'bg-green-600 text-white' : 'bg-white text-gray-600'
+          }`}
+          onClick={() => { setMode('batch'); setFlowerId('') }}
+        >
+          По партии
+        </button>
+      </div>
+
+      {mode === 'flower' && (
+        <select
+          value={flowerId}
+          onChange={(e) => setFlowerId(e.target.value)}
+          className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white mb-4"
+        >
+          <option value="">Все цветы</option>
+          {flowers.map((f) => (
+            <option key={f.flower_id} value={f.flower_id}>
+              {f.name}
+            </option>
+          ))}
+        </select>
+      )}
+
+      {mode === 'batch' && (
+        <select
+          value={selectedDelivery?.id || ''}
+          onChange={(e) => handleDeliverySelect(e.target.value)}
+          className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white mb-4"
+        >
+          <option value="">Выбрать партию</option>
+          {deliveries.map((d) => (
+            <option key={d.id} value={d.id}>
+              {formatDate(d.delivered_at)} · {d.suppliers?.name} · {posLabel(d.delivery_items?.length || 0)}
+            </option>
+          ))}
+        </select>
+      )}
+
+      {showPopup && selectedDelivery && (
+        <BatchPopup delivery={selectedDelivery} onClose={() => setShowPopup(false)} />
+      )}
 
       {loading && (
         <p className="text-center text-gray-400 text-sm mt-6">Загрузка...</p>
@@ -57,15 +179,10 @@ export default function HistoryPage() {
         </div>
       )}
 
-      {!loading && !error && movements.length === 0 && (
-        <p className="text-center text-gray-400 text-sm mt-6">Движений нет</p>
-      )}
-
       {!loading && !error && movements.length > 0 && (
         <ul className="space-y-2">
           {movements.map((m) => {
-            const typeStyle = TYPE_STYLES[m.movement_type] ?? 'bg-gray-100 text-gray-600'
-            const sign = TYPE_SIGN[m.movement_type] ?? ''
+            const { label, tagClass, sign, extra } = getMovementDisplay(m)
             return (
               <li
                 key={m.id}
@@ -74,10 +191,11 @@ export default function HistoryPage() {
                 <div>
                   <p className="text-sm font-medium text-gray-800">{m.flowers?.name}</p>
                   <p className="text-xs text-gray-400 mt-0.5">{formatDate(m.created_at)}</p>
+                  {extra && <p className="text-xs text-gray-500 mt-0.5">{extra}</p>}
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${typeStyle}`}>
-                    {m.movement_type}
+                  <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${tagClass}`}>
+                    {label}
                   </span>
                   <span className="text-sm font-semibold text-gray-700">
                     {sign}{Math.abs(m.quantity)}

--- a/src/tests/HistoryPage.test.jsx
+++ b/src/tests/HistoryPage.test.jsx
@@ -8,13 +8,29 @@ vi.mock('../hooks/useFlowerStock', () => ({
 vi.mock('../hooks/useMovementHistory', () => ({
   useMovementHistory: vi.fn(),
 }))
+vi.mock('../hooks/useBatchDeliveries', () => ({
+  useBatchDeliveries: vi.fn(),
+}))
 
 import { useFlowerStock } from '../hooks/useFlowerStock'
 import { useMovementHistory } from '../hooks/useMovementHistory'
+import { useBatchDeliveries } from '../hooks/useBatchDeliveries'
 
 const FLOWERS = [
   { flower_id: '1', name: 'Роза', total: 10, reserved: 2, available: 8, stale: false },
   { flower_id: '2', name: 'Тюльпан', total: 5, reserved: 0, available: 5, stale: false },
+]
+
+const DELIVERIES = [
+  {
+    id: 'd1',
+    delivered_at: '2026-03-17',
+    suppliers: { name: 'Марина' },
+    delivery_items: [
+      { id: 'di1', flower_id: '1', quantity: 100, batch_id: 'b1', flowers: { name: 'Роза' } },
+      { id: 'di2', flower_id: '2', quantity: 50, batch_id: 'b2', flowers: { name: 'Тюльпан' } },
+    ],
+  },
 ]
 
 describe('HistoryPage', () => {
@@ -22,18 +38,20 @@ describe('HistoryPage', () => {
     vi.clearAllMocks()
     useFlowerStock.mockReturnValue({ flowers: FLOWERS, loading: false, error: null })
     useMovementHistory.mockReturnValue({ movements: [], loading: false, error: null, refresh: vi.fn() })
+    useBatchDeliveries.mockReturnValue({ deliveries: DELIVERIES, loading: false, error: null })
   })
 
-  it('показывает фильтр со списком цветов', () => {
+  it('показывает переключатель режимов', () => {
+    render(<HistoryPage />)
+    expect(screen.getByText('По цветку')).toBeDefined()
+    expect(screen.getByText('По партии')).toBeDefined()
+  })
+
+  it('в режиме по цветку показывает фильтр со списком цветов', () => {
     render(<HistoryPage />)
     expect(screen.getByText('Все цветы')).toBeDefined()
     expect(screen.getByText('Роза')).toBeDefined()
     expect(screen.getByText('Тюльпан')).toBeDefined()
-  })
-
-  it('показывает пустое состояние', () => {
-    render(<HistoryPage />)
-    expect(screen.getByText('Движений нет')).toBeDefined()
   })
 
   it('показывает загрузку', () => {
@@ -51,7 +69,12 @@ describe('HistoryPage', () => {
     expect(refresh).toHaveBeenCalledOnce()
   })
 
-  it('отображает строки движений', () => {
+  it('не показывает текст при пустом состоянии', () => {
+    render(<HistoryPage />)
+    expect(screen.queryByText('Движений нет')).toBeNull()
+  })
+
+  it('отображает строки движений с цветовыми тегами', () => {
     useMovementHistory.mockReturnValue({
       movements: [
         {
@@ -61,6 +84,9 @@ describe('HistoryPage', () => {
           movement_type: 'поставка',
           quantity: 20,
           created_at: '2026-03-15T10:00:00Z',
+          orders: null,
+          defects: null,
+          batches: null,
         },
         {
           id: '2',
@@ -69,6 +95,9 @@ describe('HistoryPage', () => {
           movement_type: 'резерв',
           quantity: 5,
           created_at: '2026-03-14T09:00:00Z',
+          orders: { client_name: 'Тамара', ready_at: '2026-03-26T00:00:00Z' },
+          defects: null,
+          batches: null,
         },
       ],
       loading: false,
@@ -76,18 +105,104 @@ describe('HistoryPage', () => {
       refresh: vi.fn(),
     })
     render(<HistoryPage />)
-    // 2 строки движений + 1 опция в фильтре = 3
-    expect(screen.getAllByText('Роза')).toHaveLength(3)
     expect(screen.getByText('поставка')).toBeDefined()
     expect(screen.getByText('резерв')).toBeDefined()
     expect(screen.getByText('+20')).toBeDefined()
     expect(screen.getByText('-5')).toBeDefined()
   })
 
+  it('показывает имя клиента и дату в резерве', () => {
+    useMovementHistory.mockReturnValue({
+      movements: [
+        {
+          id: '1',
+          flower_id: '1',
+          flowers: { name: 'Роза' },
+          movement_type: 'резерв',
+          quantity: 9,
+          created_at: '2026-03-14T09:00:00Z',
+          orders: { client_name: 'Тамара', ready_at: '2026-03-26T00:00:00Z' },
+          defects: null,
+          batches: null,
+        },
+      ],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    })
+    render(<HistoryPage />)
+    expect(screen.getByText(/Тамара/)).toBeDefined()
+  })
+
+  it('показывает ⚠️ брак для списания', () => {
+    useMovementHistory.mockReturnValue({
+      movements: [
+        {
+          id: '1',
+          flower_id: '1',
+          flowers: { name: 'Роза' },
+          movement_type: 'списание',
+          quantity: 5,
+          created_at: '2026-03-14T09:00:00Z',
+          orders: null,
+          defects: { defect_type: 'гнилой' },
+          batches: null,
+        },
+      ],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    })
+    render(<HistoryPage />)
+    expect(screen.getByText('⚠️ брак')).toBeDefined()
+    expect(screen.getByText('списание')).toBeDefined()
+  })
+
+  it('показывает жёлтый тег для не_тот_заказ', () => {
+    useMovementHistory.mockReturnValue({
+      movements: [
+        {
+          id: '1',
+          flower_id: '1',
+          flowers: { name: 'Роза' },
+          movement_type: 'поставка',
+          quantity: 50,
+          created_at: '2026-03-14T09:00:00Z',
+          orders: null,
+          defects: null,
+          batches: { delivery_items: [{ reception_status: 'не_тот_заказ', comment: 'красные вместо белых' }] },
+        },
+      ],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+    })
+    render(<HistoryPage />)
+    expect(screen.getByText('на складе')).toBeDefined()
+    expect(screen.getByText('⚠️ красные вместо белых')).toBeDefined()
+  })
+
+  it('переключается в режим по партии', () => {
+    render(<HistoryPage />)
+    fireEvent.click(screen.getByText('По партии'))
+    expect(screen.getByText('Выбрать партию')).toBeDefined()
+    expect(screen.getByText(/Марина/)).toBeDefined()
+  })
+
+  it('открывает попап при выборе партии', () => {
+    render(<HistoryPage />)
+    fireEvent.click(screen.getByText('По партии'))
+    const select = screen.getByRole('combobox')
+    fireEvent.change(select, { target: { value: 'd1' } })
+    expect(screen.getByText('Роза')).toBeDefined()
+    expect(screen.getByText('100 шт')).toBeDefined()
+    expect(screen.getByText('50 шт')).toBeDefined()
+  })
+
   it('передаёт flower_id в хук при выборе фильтра', () => {
     render(<HistoryPage />)
     const select = screen.getByRole('combobox')
     fireEvent.change(select, { target: { value: '1' } })
-    expect(useMovementHistory).toHaveBeenLastCalledWith('1')
+    expect(useMovementHistory).toHaveBeenLastCalledWith('1', null)
   })
 })


### PR DESCRIPTION
…#10)

- Добавлен переключатель «По цветку» / «По партии»
- Дропдаун партий: дата · поставщик · N позиций
- Тап на партию → всплывающий блок с составом поставки
- Резерв показывает имя клиента и дату заказа
- Списание (брак): красный тег + ⚠️ брак
- Не тот заказ: жёлтый тег «на складе» + ⚠️ комментарий
- Пустое состояние: ничего не показывать
- Новый хук useBatchDeliveries
- useMovementHistory расширен: orders, defects, delivery_items
- Тесты обновлены (12 тестов)

https://claude.ai/code/session_01LcJUuNQvfhF1CShntnhSQs