### PR TITLE
feat: UI/UX redesign — все экраны (#34)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,11 +7,51 @@ import DeliveryPage from './pages/DeliveryPage'
 import NewOrderPage from './pages/NewOrderPage'
 
 const TABS = [
-  { id: 'stock', label: 'Остатки' },
-  { id: 'delivery', label: 'Поставка' },
-  { id: 'orders', label: 'Заказы' },
-  { id: 'history', label: 'История' },
-  { id: 'suppliers', label: 'Поставщики' },
+  {
+    id: 'stock',
+    label: 'Остатки',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
+        <path d="M3 3h7v7H3V3zm11 0h7v7h-7V3zm0 11h7v7h-7v-7zM3 14h7v7H3v-7z" />
+      </svg>
+    ),
+  },
+  {
+    id: 'delivery',
+    label: 'Поставка',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
+        <path d="M20 8h-3V4H3c-1.1 0-2 .9-2 2v11h2c0 1.66 1.34 3 3 3s3-1.34 3-3h6c0 1.66 1.34 3 3 3s3-1.34 3-3h2v-5l-3-4zm-1.5 1.5 1.96 2.5H17V9.5h1.5zM6 18c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm2.22-3c-.55-.61-1.35-1-2.22-1s-1.67.39-2.22 1H3V6h12v9H8.22zM18 18c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1z" />
+      </svg>
+    ),
+  },
+  {
+    id: 'orders',
+    label: 'Заказы',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
+        <path d="M19 3h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm2 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z" />
+      </svg>
+    ),
+  },
+  {
+    id: 'history',
+    label: 'История',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
+        <path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67V7z" />
+      </svg>
+    ),
+  },
+  {
+    id: 'suppliers',
+    label: 'Поставщики',
+    icon: (
+      <svg viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
+        <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
+      </svg>
+    ),
+  },
 ]
 
 const PAGE_TITLES = {
@@ -23,34 +63,76 @@ const PAGE_TITLES = {
   suppliers: 'Поставщики',
 }
 
+const TABS_WITH_ADD = ['stock', 'orders', 'delivery', 'suppliers']
+
 export default function App() {
   const [tab, setTab] = useState('stock')
+  const [stockAddOpen, setStockAddOpen] = useState(false)
+  const [supplierAddOpen, setSupplierAddOpen] = useState(false)
+  const [deliveryAddOpen, setDeliveryAddOpen] = useState(false)
+
+  function handleHeaderAdd() {
+    if (tab === 'stock') setStockAddOpen(true)
+    else if (tab === 'orders') setTab('neworder')
+    else if (tab === 'suppliers') setSupplierAddOpen(true)
+    else if (tab === 'delivery') setDeliveryAddOpen(true)
+  }
+
+  const showAddBtn = TABS_WITH_ADD.includes(tab)
 
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
-      <header className="bg-green-600 text-white px-4 py-3 shadow sticky top-0 z-10">
-        <h1 className="text-lg font-semibold">{PAGE_TITLES[tab]}</h1>
+      <header className="bg-white border-b border-gray-100 px-4 py-3 sticky top-0 z-10 flex items-center justify-between shadow-sm">
+        <h1 className="text-[22px] font-medium text-gray-900 leading-tight">{PAGE_TITLES[tab]}</h1>
+        {showAddBtn && (
+          <button
+            onClick={handleHeaderAdd}
+            className="bg-green-500 text-white text-sm font-medium px-3 py-1.5 rounded-full leading-none"
+          >
+            +
+          </button>
+        )}
       </header>
+
       <main className="px-4 py-4 flex-1">
-        {tab === 'stock' && <StockPage />}
+        {tab === 'stock' && (
+          <StockPage
+            addModalOpen={stockAddOpen}
+            onAddClose={() => setStockAddOpen(false)}
+          />
+        )}
         {tab === 'neworder' && <NewOrderPage onBack={() => setTab('orders')} />}
-        {tab === 'delivery' && <DeliveryPage />}
-        {tab === 'orders' && <OrdersPage onNewOrder={() => setTab('neworder')} />}
+        {tab === 'delivery' && (
+          <DeliveryPage
+            addFormOpen={deliveryAddOpen}
+            onAddFormClose={() => setDeliveryAddOpen(false)}
+          />
+        )}
+        {tab === 'orders' && <OrdersPage />}
         {tab === 'history' && <HistoryPage />}
-        {tab === 'suppliers' && <SuppliersPage />}
+        {tab === 'suppliers' && (
+          <SuppliersPage
+            addFormOpen={supplierAddOpen}
+            onAddFormClose={() => setSupplierAddOpen(false)}
+          />
+        )}
       </main>
-      <nav className="sticky bottom-0 bg-white border-t border-gray-200 flex">
+
+      <nav className="sticky bottom-0 bg-white border-t border-gray-100 flex">
         {TABS.map((t) => (
           <button
             key={t.id}
             onClick={() => setTab(t.id)}
-            className={`flex-1 py-3 text-sm font-medium ${
-              tab === t.id
-                ? 'text-green-600 border-t-2 border-green-600'
-                : 'text-gray-500'
-            }`}
+            className="flex-1 py-2 flex flex-col items-center gap-0.5"
           >
-            {t.label}
+            <span
+              className={`flex flex-col items-center gap-0.5 px-3 py-1 rounded-full transition-colors ${
+                tab === t.id ? 'bg-green-50 text-green-600' : 'text-gray-400'
+              }`}
+            >
+              {t.icon}
+              <span className="text-[11px] font-medium leading-none">{t.label}</span>
+            </span>
           </button>
         ))}
       </nav>

--- a/src/components/DeliveryCard.jsx
+++ b/src/components/DeliveryCard.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useDeliveryStatus, DELIVERY_STATUSES } from '../hooks/useDeliveryStatus'
+import { useDeliveryStatus } from '../hooks/useDeliveryStatus'
 
 const STATUS_STYLES = {
   'оформлено': 'bg-blue-100 text-blue-700',
@@ -38,24 +38,23 @@ export default function DeliveryCard({ delivery, onAccept, onRefresh }) {
   }
 
   return (
-    <div className="bg-white rounded-xl p-4 shadow-sm">
-      <div className="flex items-start justify-between mb-2">
-        <div>
-          <span className="font-medium text-gray-900">
-            {suppliers?.name}
-            {has_issues && <span className="ml-1">⚠️</span>}
-          </span>
-          {delivered_at && (
-            <span className="block text-xs text-gray-400">{formatDate(delivered_at)}</span>
-          )}
-        </div>
-        <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${statusStyle}`}>
+    <div className="bg-white rounded-2xl p-4 border border-gray-100">
+      <div className="flex items-start justify-between mb-1">
+        <span className="text-[17px] font-semibold text-gray-900 leading-tight">
+          {suppliers?.name}
+          {has_issues && <span className="ml-1">⚠️</span>}
+        </span>
+        <span className={`text-xs px-2 py-0.5 rounded-full font-medium ml-2 whitespace-nowrap ${statusStyle}`}>
           {status}
         </span>
       </div>
 
+      {delivered_at && (
+        <p className="text-[13px] text-gray-400 mb-2">{formatDate(delivered_at)}</p>
+      )}
+
       {delivery_items.length > 0 && (
-        <p className="text-sm text-gray-600 mb-2">
+        <p className="text-[14px] text-gray-500 mb-3">
           {delivery_items.map((i) => `${i.flowers?.name} × ${i.quantity}`).join(', ')}
         </p>
       )}
@@ -66,7 +65,7 @@ export default function DeliveryCard({ delivery, onAccept, onRefresh }) {
         <button
           onClick={goingToWarehouse ? onAccept : handleAdvance}
           disabled={advancing}
-          className="w-full border border-green-600 text-green-600 text-xs py-1.5 rounded-lg disabled:opacity-50"
+          className="w-full bg-gray-100 text-gray-700 text-sm py-2.5 rounded-xl font-medium disabled:opacity-50"
         >
           {advancing ? '...' : `→ ${next}`}
         </button>

--- a/src/components/OrderCard.jsx
+++ b/src/components/OrderCard.jsx
@@ -5,42 +5,61 @@ const STATUS_STYLES = {
   'готов к доставке': 'bg-green-100 text-green-700',
 }
 
+const NEXT_STATUS = {
+  'новый': 'в работе',
+  'в работе': null,
+}
+
+function nextOrderStatus(status, deliveryType) {
+  if (status === 'новый') return 'в работе'
+  if (status === 'в работе') {
+    return deliveryType === 'доставка' ? 'готов к доставке' : 'готов к выдаче'
+  }
+  return null
+}
+
 function formatDate(dateStr) {
   if (!dateStr) return null
   const d = new Date(dateStr)
   return d.toLocaleDateString('ru-RU', { day: 'numeric', month: 'short' })
 }
 
-export default function OrderCard({ order }) {
+export default function OrderCard({ order, onStatusChange }) {
   const { client_name, client_phone, delivery_type, delivery_address, status, ready_at, order_items = [] } = order
   const statusStyle = STATUS_STYLES[status] || 'bg-gray-100 text-gray-600'
   const isDelivery = delivery_type === 'доставка'
+  const next = nextOrderStatus(status, delivery_type)
 
   return (
-    <div className="bg-white rounded-xl p-4 shadow-sm border border-transparent">
-      <div className="flex items-start justify-between mb-2">
-        <div>
-          <span className="font-medium text-gray-900">{client_name}</span>
-          {client_phone && (
-            <span className="block text-xs text-gray-400">{client_phone}</span>
-          )}
-        </div>
-        <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${statusStyle}`}>
+    <div className="bg-white rounded-2xl p-4 border border-gray-100">
+      <div className="flex items-start justify-between mb-1">
+        <span className="text-[17px] font-bold text-gray-900 leading-tight">{client_name}</span>
+        <span className={`text-xs px-2 py-0.5 rounded-full font-medium ml-2 whitespace-nowrap ${statusStyle}`}>
           {status}
         </span>
       </div>
 
       {order_items.length > 0 && (
-        <p className="text-sm text-gray-600 mb-2">
+        <p className="text-[14px] text-gray-500 mb-2">
           {order_items.map((item) => `${item.flowers?.name} × ${item.quantity}`).join(', ')}
         </p>
       )}
 
-      <div className="flex items-center gap-3 text-xs text-gray-400">
+      <div className="flex items-center gap-3 text-[13px] text-gray-400 mb-3">
         <span>{isDelivery ? '🚚 доставка' : '🏪 самовывоз'}</span>
         {ready_at && <span>к {formatDate(ready_at)}</span>}
         {isDelivery && delivery_address && <span className="truncate">{delivery_address}</span>}
+        {client_phone && <span>{client_phone}</span>}
       </div>
+
+      {next && onStatusChange && (
+        <button
+          onClick={() => onStatusChange(order.id, next)}
+          className="w-full bg-gray-100 text-gray-700 text-sm py-2.5 rounded-xl font-medium"
+        >
+          → {next}
+        </button>
+      )}
     </div>
   )
 }

--- a/src/pages/DeliveryPage.jsx
+++ b/src/pages/DeliveryPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useSuppliers } from '../hooks/useSuppliers'
 import { useFlowerStock } from '../hooks/useFlowerStock'
 import { useDelivery } from '../hooks/useDelivery'
@@ -11,7 +11,7 @@ function newRow() {
   return { id: Date.now() + Math.random(), flowerId: '', quantity: '' }
 }
 
-export default function DeliveryPage() {
+export default function DeliveryPage({ addFormOpen, onAddFormClose }) {
   const [showForm, setShowForm] = useState(false)
   const [filter, setFilter] = useState('active')
   const [acceptingDelivery, setAcceptingDelivery] = useState(null)
@@ -32,6 +32,15 @@ export default function DeliveryPage() {
   const [newFlowerRowId, setNewFlowerRowId] = useState(null)
   const [newFlowerName, setNewFlowerName] = useState('')
   const [addingFlower, setAddingFlower] = useState(false)
+
+  useEffect(() => {
+    if (addFormOpen) setShowForm(true)
+  }, [addFormOpen])
+
+  function handleFormClose() {
+    setShowForm(false)
+    onAddFormClose?.()
+  }
 
   function updateRow(id, patch) {
     setRows((prev) => prev.map((r) => (r.id === id ? { ...r, ...patch } : r)))
@@ -79,6 +88,7 @@ export default function DeliveryPage() {
       setSupplierId('')
       setDeliveredAt(new Date().toISOString().split('T')[0])
       setShowForm(false)
+      onAddFormClose?.()
       refresh()
     } catch (err) {
       setError(err.message || 'Ошибка сохранения')
@@ -108,18 +118,16 @@ export default function DeliveryPage() {
         </p>
       )}
 
-      <button
-        onClick={() => setShowForm((v) => !v)}
-        className="w-full bg-green-600 text-white text-sm py-3 rounded-xl"
-      >
-        {showForm ? 'Скрыть форму' : '+ Новая поставка'}
-      </button>
-
       {showForm && (
         <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="flex items-center justify-between">
+            <p className="font-semibold text-gray-800 text-sm">Новая поставка</p>
+            <button type="button" onClick={handleFormClose} className="text-gray-400 text-lg leading-none">✕</button>
+          </div>
+
           {error && <p className="text-red-500 text-sm text-center">{error}</p>}
 
-          <div className="bg-white rounded-xl p-4 shadow-sm space-y-3">
+          <div className="bg-white rounded-2xl p-4 border border-gray-100 space-y-3">
             <div>
               <label className="block text-xs text-gray-500 mb-1">Поставщик</label>
               <select
@@ -147,7 +155,7 @@ export default function DeliveryPage() {
           </div>
 
           {rows.map((row, idx) => (
-            <div key={row.id} className="bg-white rounded-xl p-4 shadow-sm space-y-3">
+            <div key={row.id} className="bg-white rounded-2xl p-4 border border-gray-100 space-y-3">
               <div className="flex items-center justify-between">
                 <span className="text-xs text-gray-500 font-medium">Позиция {idx + 1}</span>
                 {rows.length > 1 && (
@@ -236,19 +244,19 @@ export default function DeliveryPage() {
         </form>
       )}
 
-      <div className="flex gap-2">
+      <div className="flex bg-gray-100 rounded-full p-0.5 gap-0.5">
         <button
           onClick={() => setFilter('active')}
-          className={`flex-1 py-2 text-sm rounded-xl border ${
-            filter === 'active' ? 'bg-green-600 text-white border-green-600' : 'border-gray-300 text-gray-600'
+          className={`flex-1 py-2 text-sm rounded-full transition-colors font-medium ${
+            filter === 'active' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500'
           }`}
         >
           Активные
         </button>
         <button
           onClick={() => setFilter('all')}
-          className={`flex-1 py-2 text-sm rounded-xl border ${
-            filter === 'all' ? 'bg-green-600 text-white border-green-600' : 'border-gray-300 text-gray-600'
+          className={`flex-1 py-2 text-sm rounded-full transition-colors font-medium ${
+            filter === 'all' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500'
           }`}
         >
           Все

--- a/src/pages/HistoryPage.jsx
+++ b/src/pages/HistoryPage.jsx
@@ -113,18 +113,18 @@ export default function HistoryPage() {
 
   return (
     <div>
-      <div className="flex rounded-lg overflow-hidden border border-gray-200 mb-4">
+      <div className="flex bg-gray-100 rounded-full p-0.5 gap-0.5 mb-4">
         <button
-          className={`flex-1 py-2 text-sm font-medium transition-colors ${
-            mode === 'flower' ? 'bg-green-600 text-white' : 'bg-white text-gray-600'
+          className={`flex-1 py-2 text-sm font-medium rounded-full transition-colors ${
+            mode === 'flower' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500'
           }`}
           onClick={() => { setMode('flower'); setSelectedDelivery(null) }}
         >
           По цветку
         </button>
         <button
-          className={`flex-1 py-2 text-sm font-medium transition-colors ${
-            mode === 'batch' ? 'bg-green-600 text-white' : 'bg-white text-gray-600'
+          className={`flex-1 py-2 text-sm font-medium rounded-full transition-colors ${
+            mode === 'batch' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500'
           }`}
           onClick={() => { setMode('batch'); setFlowerId('') }}
         >

--- a/src/pages/OrdersPage.jsx
+++ b/src/pages/OrdersPage.jsx
@@ -1,7 +1,7 @@
 import OrderCard from '../components/OrderCard'
 import { useOrders } from '../hooks/useOrders'
 
-export default function OrdersPage({ onNewOrder }) {
+export default function OrdersPage() {
   const { orders, loading, error, refresh } = useOrders()
 
   if (loading) {
@@ -21,12 +21,6 @@ export default function OrdersPage({ onNewOrder }) {
 
   return (
     <div className="space-y-3">
-      <button
-        onClick={onNewOrder}
-        className="w-full bg-green-600 text-white text-sm py-3 rounded-xl"
-      >
-        + Новый заказ
-      </button>
       {orders.length === 0 ? (
         <p className="text-center text-gray-400 mt-6 text-sm">Активных заказов нет</p>
       ) : (

--- a/src/pages/StockPage.jsx
+++ b/src/pages/StockPage.jsx
@@ -71,12 +71,14 @@ function AddFlowerModal({ onSave, onClose }) {
   )
 }
 
-export default function StockPage() {
+export default function StockPage({ addModalOpen, onAddClose }) {
   const { flowers, loading, error, refresh } = useFlowerStock()
   const { updateThreshold } = useAddFlower()
-  const [showAddModal, setShowAddModal] = useState(false)
 
   const lowStockCount = flowers.filter((f) => f.available <= f.low_stock_threshold).length
+  const totalAvailable = flowers.reduce((s, f) => s + (f.available || 0), 0)
+  const totalReserved = flowers.reduce((s, f) => s + (f.reserved || 0), 0)
+  const totalAll = flowers.reduce((s, f) => s + (f.total || 0), 0)
 
   async function handleThresholdChange(flowerId, threshold) {
     await updateThreshold(flowerId, threshold)
@@ -100,6 +102,25 @@ export default function StockPage() {
 
   return (
     <div>
+      <div className="grid grid-cols-4 gap-2 mb-4">
+        <div className="bg-white rounded-2xl border border-gray-100 p-3 text-center">
+          <p className="text-lg font-bold text-green-600">{totalAvailable}</p>
+          <p className="text-[11px] text-gray-400 leading-tight">свободно</p>
+        </div>
+        <div className="bg-white rounded-2xl border border-gray-100 p-3 text-center">
+          <p className="text-lg font-bold text-yellow-500">{totalReserved}</p>
+          <p className="text-[11px] text-gray-400 leading-tight">резерв</p>
+        </div>
+        <div className="bg-white rounded-2xl border border-gray-100 p-3 text-center">
+          <p className="text-lg font-bold text-gray-600">{totalAll}</p>
+          <p className="text-[11px] text-gray-400 leading-tight">всего</p>
+        </div>
+        <div className="bg-white rounded-2xl border border-gray-100 p-3 text-center">
+          <p className="text-lg font-bold text-gray-600">{flowers.length}</p>
+          <p className="text-[11px] text-gray-400 leading-tight">видов</p>
+        </div>
+      </div>
+
       {lowStockCount > 0 && (
         <div className="bg-yellow-50 border border-yellow-200 rounded-xl px-4 py-3 mb-4 flex items-center gap-2">
           <span className="text-yellow-700 text-sm font-medium">
@@ -107,15 +128,6 @@ export default function StockPage() {
           </span>
         </div>
       )}
-
-      <div className="flex justify-end mb-3">
-        <button
-          onClick={() => setShowAddModal(true)}
-          className="text-sm text-green-600 font-medium"
-        >
-          + Добавить цветок
-        </button>
-      </div>
 
       {flowers.length === 0 ? (
         <p className="text-center text-gray-400 mt-10 text-sm">Цветы ещё не добавлены</p>
@@ -131,10 +143,10 @@ export default function StockPage() {
         </div>
       )}
 
-      {showAddModal && (
+      {addModalOpen && (
         <AddFlowerModal
-          onSave={() => { setShowAddModal(false); refresh() }}
-          onClose={() => setShowAddModal(false)}
+          onSave={() => { onAddClose(); refresh() }}
+          onClose={onAddClose}
         />
       )}
     </div>

--- a/src/pages/SuppliersPage.jsx
+++ b/src/pages/SuppliersPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useSuppliers } from '../hooks/useSuppliers'
 
 const MAX_SUPPLIERS = 5
@@ -24,7 +24,7 @@ function SupplierForm({ initial, onSave, onCancel }) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="bg-white rounded-xl p-4 shadow-sm mb-4 space-y-3">
+    <form onSubmit={handleSubmit} className="bg-white rounded-2xl p-4 border border-gray-100 mb-3 space-y-3">
       <input
         type="text"
         placeholder="Имя поставщика"
@@ -45,14 +45,14 @@ function SupplierForm({ initial, onSave, onCancel }) {
         <button
           type="submit"
           disabled={saving || !name.trim()}
-          className="flex-1 bg-green-600 text-white text-sm py-2 rounded-lg disabled:opacity-50"
+          className="flex-1 bg-green-600 text-white text-sm py-2.5 rounded-xl disabled:opacity-50"
         >
           {saving ? 'Сохранение...' : 'Сохранить'}
         </button>
         <button
           type="button"
           onClick={onCancel}
-          className="flex-1 border border-gray-300 text-gray-600 text-sm py-2 rounded-lg"
+          className="flex-1 bg-gray-100 text-gray-700 text-sm py-2.5 rounded-xl"
         >
           Отмена
         </button>
@@ -61,7 +61,7 @@ function SupplierForm({ initial, onSave, onCancel }) {
   )
 }
 
-export default function SuppliersPage() {
+export default function SuppliersPage({ addFormOpen, onAddFormClose }) {
   const { suppliers, loading, error, addSupplier, updateSupplier, deleteSupplier } = useSuppliers()
   const [showAddForm, setShowAddForm] = useState(false)
   const [editingId, setEditingId] = useState(null)
@@ -69,9 +69,19 @@ export default function SuppliersPage() {
 
   const atLimit = suppliers.length >= MAX_SUPPLIERS
 
+  useEffect(() => {
+    if (addFormOpen && !atLimit) setShowAddForm(true)
+  }, [addFormOpen, atLimit])
+
+  function handleFormClose() {
+    setShowAddForm(false)
+    onAddFormClose?.()
+  }
+
   async function handleAdd(name, phone) {
     await addSupplier(name, phone)
     setShowAddForm(false)
+    onAddFormClose?.()
   }
 
   async function handleUpdate(name, phone) {
@@ -98,8 +108,12 @@ export default function SuppliersPage() {
 
   return (
     <div>
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-[13px] text-gray-400">{suppliers.length} из {MAX_SUPPLIERS}</span>
+      </div>
+
       {showAddForm && (
-        <SupplierForm onSave={handleAdd} onCancel={() => setShowAddForm(false)} />
+        <SupplierForm onSave={handleAdd} onCancel={handleFormClose} />
       )}
 
       {deleteError && (
@@ -110,7 +124,7 @@ export default function SuppliersPage() {
         <p className="text-center text-gray-400 text-sm mt-6 mb-4">Поставщики не добавлены</p>
       )}
 
-      <ul className="space-y-2 mb-4">
+      <ul className="space-y-3 mb-4">
         {suppliers.map((s) =>
           editingId === s.id ? (
             <li key={s.id}>
@@ -121,24 +135,20 @@ export default function SuppliersPage() {
               />
             </li>
           ) : (
-            <li
-              key={s.id}
-              className="bg-white rounded-xl px-4 py-3 shadow-sm flex items-center justify-between"
-            >
-              <div>
-                <p className="text-sm font-medium text-gray-900">{s.name}</p>
-                {s.phone && <p className="text-xs text-gray-400">{s.phone}</p>}
-              </div>
-              <div className="flex gap-3">
+            <li key={s.id} className="bg-white rounded-2xl px-4 py-3 border border-gray-100">
+              <p className="text-[16px] font-bold text-gray-900 mb-0.5">{s.name}</p>
+              {s.phone && <p className="text-[13px] text-gray-400 mb-3">{s.phone}</p>}
+              {!s.phone && <div className="mb-3" />}
+              <div className="flex gap-2">
                 <button
                   onClick={() => setEditingId(s.id)}
-                  className="text-xs text-blue-500"
+                  className="flex-1 bg-gray-100 text-gray-700 text-sm py-2.5 rounded-xl font-medium"
                 >
                   Изменить
                 </button>
                 <button
                   onClick={() => handleDelete(s.id)}
-                  className="text-xs text-red-400"
+                  className="flex-1 bg-gray-100 text-red-500 text-sm py-2.5 rounded-xl font-medium"
                 >
                   Удалить
                 </button>

--- a/src/tests/DeliveryPage.test.jsx
+++ b/src/tests/DeliveryPage.test.jsx
@@ -55,10 +55,6 @@ function setup(saveDeliveryOverride) {
   return { saveDelivery }
 }
 
-function openForm() {
-  fireEvent.click(screen.getByText(/новая поставка/i))
-}
-
 function fillForm() {
   const selects = screen.getAllByRole('combobox')
   fireEvent.change(selects[0], { target: { value: '1' } })   // поставщик
@@ -80,12 +76,6 @@ describe('DeliveryPage', () => {
     expect(screen.getByText(/загрузка/i)).toBeDefined()
   })
 
-  it('показывает кнопку "Новая поставка"', () => {
-    setup()
-    render(<DeliveryPage />)
-    expect(screen.getByText(/новая поставка/i)).toBeDefined()
-  })
-
   it('показывает фильтр активные/все', () => {
     setup()
     render(<DeliveryPage />)
@@ -99,18 +89,16 @@ describe('DeliveryPage', () => {
     expect(screen.getByText('Розы опт')).toBeDefined()
   })
 
-  it('открывает форму по кнопке', () => {
+  it('показывает форму когда addFormOpen=true', () => {
     setup()
-    render(<DeliveryPage />)
-    openForm()
+    render(<DeliveryPage addFormOpen={true} onAddFormClose={vi.fn()} />)
     expect(screen.getAllByText(/поставщик/i).length).toBeGreaterThan(0)
     expect(screen.getByText(/дата поставки/i)).toBeDefined()
   })
 
   it('добавляет позицию в форме', () => {
     setup()
-    render(<DeliveryPage />)
-    openForm()
+    render(<DeliveryPage addFormOpen={true} onAddFormClose={vi.fn()} />)
     expect(screen.getAllByText(/позиция/i)).toHaveLength(1)
     fireEvent.click(screen.getByText(/добавить позицию/i))
     expect(screen.getAllByText(/позиция/i)).toHaveLength(2)
@@ -118,16 +106,14 @@ describe('DeliveryPage', () => {
 
   it('кнопка "Сохранить" заблокирована при пустой форме', () => {
     setup()
-    render(<DeliveryPage />)
-    openForm()
+    render(<DeliveryPage addFormOpen={true} onAddFormClose={vi.fn()} />)
     const btn = screen.getByRole('button', { name: /сохранить поставку/i })
     expect(btn.disabled).toBe(true)
   })
 
   it('вызывает saveDelivery с корректными данными', async () => {
     const { saveDelivery } = setup()
-    render(<DeliveryPage />)
-    openForm()
+    render(<DeliveryPage addFormOpen={true} onAddFormClose={vi.fn()} />)
     fillForm()
     fireEvent.click(screen.getByRole('button', { name: /сохранить поставку/i }))
     await waitFor(() =>
@@ -144,8 +130,7 @@ describe('DeliveryPage', () => {
 
   it('скрывает форму и обновляет список после сохранения', async () => {
     setup()
-    render(<DeliveryPage />)
-    openForm()
+    render(<DeliveryPage addFormOpen={true} onAddFormClose={vi.fn()} />)
     fillForm()
     fireEvent.click(screen.getByRole('button', { name: /сохранить поставку/i }))
     await waitFor(() => expect(screen.queryByText(/дата поставки/i)).toBeNull())
@@ -154,8 +139,7 @@ describe('DeliveryPage', () => {
 
   it('показывает ошибку при неудачном сохранении', async () => {
     setup(vi.fn().mockRejectedValue(new Error('Нет сети')))
-    render(<DeliveryPage />)
-    openForm()
+    render(<DeliveryPage addFormOpen={true} onAddFormClose={vi.fn()} />)
     fillForm()
     fireEvent.click(screen.getByRole('button', { name: /сохранить поставку/i }))
     await waitFor(() => expect(screen.getByText('Нет сети')).toBeDefined())

--- a/src/tests/OrdersPage.test.jsx
+++ b/src/tests/OrdersPage.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import OrdersPage from '../pages/OrdersPage'
 import OrderCard from '../components/OrderCard'
 
@@ -53,23 +53,15 @@ describe('OrdersPage', () => {
 
   it('показывает сообщение при пустом списке', () => {
     useOrders.mockReturnValue({ orders: [], loading: false, error: null, refresh: vi.fn() })
-    render(<OrdersPage onNewOrder={vi.fn()} />)
+    render(<OrdersPage />)
     expect(screen.getByText(/активных заказов нет/i)).toBeDefined()
   })
 
   it('рендерит карточки заказов', () => {
     useOrders.mockReturnValue({ orders: mockOrders, loading: false, error: null, refresh: vi.fn() })
-    render(<OrdersPage onNewOrder={vi.fn()} />)
+    render(<OrdersPage />)
     expect(screen.getByText('Анна')).toBeDefined()
     expect(screen.getByText('Мария')).toBeDefined()
-  })
-
-  it('вызывает onNewOrder при нажатии кнопки', () => {
-    const onNewOrder = vi.fn()
-    useOrders.mockReturnValue({ orders: [], loading: false, error: null, refresh: vi.fn() })
-    render(<OrdersPage onNewOrder={onNewOrder} />)
-    fireEvent.click(screen.getByText(/новый заказ/i))
-    expect(onNewOrder).toHaveBeenCalledOnce()
   })
 })
 
@@ -100,5 +92,15 @@ describe('OrderCard', () => {
   it('не показывает телефон если его нет', () => {
     render(<OrderCard order={mockOrders[1]} />)
     expect(screen.queryByText(/\+7/)).toBeNull()
+  })
+
+  it('показывает кнопку смены статуса когда передан onStatusChange', () => {
+    render(<OrderCard order={mockOrders[0]} onStatusChange={vi.fn()} />)
+    expect(screen.getByText(/→ в работе/)).toBeDefined()
+  })
+
+  it('не показывает кнопку смены статуса без onStatusChange', () => {
+    render(<OrderCard order={mockOrders[0]} />)
+    expect(screen.queryByText(/→/)).toBeNull()
   })
 })

--- a/src/tests/StockPage.test.jsx
+++ b/src/tests/StockPage.test.jsx
@@ -79,4 +79,17 @@ describe('StockPage', () => {
     render(<StockPage />)
     expect(screen.getByText(/3 цветка заканчиваются/)).toBeDefined()
   })
+
+  it('показывает блок метрик с правильными суммами', () => {
+    const flowers = [
+      { flower_id: '1', name: 'Роза', total: 10, reserved: 2, available: 8, stale: false, low_stock_threshold: 5 },
+      { flower_id: '2', name: 'Тюльпан', total: 5, reserved: 1, available: 4, stale: false, low_stock_threshold: 5 },
+    ]
+    useFlowerStock.mockReturnValue({ flowers, loading: false, error: null, refresh: vi.fn() })
+    render(<StockPage />)
+    expect(screen.getAllByText('свободно').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('резерв').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('всего').length).toBeGreaterThan(0)
+    expect(screen.getByText('видов')).toBeDefined()
+  })
 })

--- a/src/tests/SuppliersPage.test.jsx
+++ b/src/tests/SuppliersPage.test.jsx
@@ -59,6 +59,12 @@ describe('SuppliersPage', () => {
     expect(screen.getByText('ЦветТорг')).toBeDefined()
   })
 
+  it('показывает счётчик "N из 5"', () => {
+    useSuppliers.mockReturnValue(defaultMock({ suppliers: mockSuppliers }))
+    render(<SuppliersPage />)
+    expect(screen.getByText('2 из 5')).toBeDefined()
+  })
+
   it('кнопка «Добавить» активна когда < 5 поставщиков', () => {
     useSuppliers.mockReturnValue(defaultMock({ suppliers: mockSuppliers }))
     render(<SuppliersPage />)


### PR DESCRIPTION
- Белый топбар (22px, font-medium) вместо зелёного header
- Кнопка "+" в топбаре, открывает модалки через App-пропы
- Нижняя навигация: SVG-иконки + зелёная pill для активной вкладки
- StockPage: блок метрик (свободно/резерв/всего/видов)
- OrderCard: имя 17px bold, состав 14px gray, кнопка статуса bg-gray-100
- DeliveryCard: имя поставщика 17px, кнопка статуса bg-gray-100
- DeliveryPage/HistoryPage: pill-тогглер фильтра/режима
- SuppliersPage: счётчик "N из 5", имя 16px bold, две кнопки на всю ширину
- Тесты обновлены; 87/87 ✓

https://claude.ai/code/session_01LcJUuNQvfhF1CShntnhSQs