### PR TITLE
feat: тикет #19 — фиксация брака через inline keyboard

### DIFF
--- a/bot/handlers/defect.js
+++ b/bot/handlers/defect.js
@@ -1,0 +1,227 @@
+'use strict'
+
+const { getSuppliers, getFlowers, saveDefect } = require('../lib/supabase')
+
+const STEPS = {
+  SUPPLIER_SELECT: 'SUPPLIER_SELECT',
+  FLOWER_SELECT: 'FLOWER_SELECT',
+  QUANTITY_INPUT: 'QUANTITY_INPUT',
+  TYPE_SELECT: 'TYPE_SELECT',
+  CONFIRM: 'CONFIRM',
+}
+
+// Хранилище состояний по Telegram ID
+const sessions = new Map()
+
+function getSession(userId) { return sessions.get(userId) }
+function setSession(userId, data) { sessions.set(userId, data) }
+function clearSession(userId) { sessions.delete(userId) }
+
+function formatSummary(session) {
+  const typeLabel = session.defectType === 'гнилой' ? '🗑 Гнилые' : '🎨 Не тот цвет'
+  const action = session.defectType === 'гнилой'
+    ? 'Остаток уменьшится, движение «списание» запишется'
+    : 'Остаток не изменится, запись с пометкой добавится'
+  return (
+    `⚠️ *Брак — подтверждение*\n\n` +
+    `Поставщик: ${session.supplierName}\n` +
+    `Цветок: ${session.flowerName}\n` +
+    `Количество: ${session.quantity} шт.\n` +
+    `Тип: ${typeLabel}\n\n` +
+    `_${action}_`
+  )
+}
+
+async function showSupplierSelect(ctx, suppliers) {
+  const buttons = suppliers.map((s) => [
+    { text: s.name, callback_data: `ds_s_${s.id}` },
+  ])
+  buttons.push([{ text: '❌ Отмена', callback_data: 'ds_cancel' }])
+  await ctx.reply('Выбери поставщика:', {
+    reply_markup: { inline_keyboard: buttons },
+  })
+}
+
+async function showFlowerSelect(ctx, flowers) {
+  const buttons = flowers.map((f) => [
+    { text: f.name, callback_data: `ds_f_${f.id}` },
+  ])
+  buttons.push([{ text: '❌ Отмена', callback_data: 'ds_cancel' }])
+  await ctx.reply('Выбери цветок:', {
+    reply_markup: { inline_keyboard: buttons },
+  })
+}
+
+async function startDefect(ctx) {
+  const userId = ctx.from.id
+  clearSession(userId)
+
+  let suppliers
+  try {
+    suppliers = await getSuppliers()
+  } catch {
+    return ctx.reply('Ошибка загрузки поставщиков. Попробуй ещё раз.')
+  }
+
+  setSession(userId, {
+    step: STEPS.SUPPLIER_SELECT,
+    supplierId: null,
+    supplierName: null,
+    flowerId: null,
+    flowerName: null,
+    quantity: null,
+    defectType: null,
+    suppliers,
+    flowers: [],
+  })
+
+  await showSupplierSelect(ctx, suppliers)
+}
+
+// Возвращает true если обработал, false — не наш callback
+async function handleCallbackQuery(ctx) {
+  const data = ctx.callbackQuery.data
+  if (!data.startsWith('ds_')) return false
+
+  const userId = ctx.from.id
+
+  if (data === 'ds_cancel') {
+    clearSession(userId)
+    await ctx.answerCbQuery()
+    await ctx.editMessageText('❌ Брак отменён.')
+    return true
+  }
+
+  const session = getSession(userId)
+  if (!session) {
+    await ctx.answerCbQuery('Сессия истекла. Начни заново через меню.')
+    return true
+  }
+
+  if (session.step === STEPS.SUPPLIER_SELECT && data.startsWith('ds_s_')) {
+    const id = data.slice(5)
+    const supplier = session.suppliers.find((s) => String(s.id) === id)
+    session.supplierId = id
+    session.supplierName = supplier ? supplier.name : id
+    session.step = STEPS.FLOWER_SELECT
+
+    let flowers
+    try {
+      flowers = await getFlowers()
+    } catch {
+      await ctx.answerCbQuery()
+      await ctx.reply('Ошибка загрузки цветов. Попробуй ещё раз.')
+      return true
+    }
+    session.flowers = flowers
+    setSession(userId, session)
+
+    await ctx.answerCbQuery()
+    await ctx.editMessageText(`Поставщик: ${session.supplierName}`)
+    await showFlowerSelect(ctx, flowers)
+    return true
+  }
+
+  if (session.step === STEPS.FLOWER_SELECT && data.startsWith('ds_f_')) {
+    const id = data.slice(5)
+    const flower = session.flowers.find((f) => String(f.id) === id)
+    session.flowerId = id
+    session.flowerName = flower ? flower.name : id
+    session.step = STEPS.QUANTITY_INPUT
+    setSession(userId, session)
+
+    await ctx.answerCbQuery()
+    await ctx.editMessageText(
+      `Цветок: *${session.flowerName}*\n\nВведи количество бракованных (штук):`,
+      { parse_mode: 'Markdown' }
+    )
+    return true
+  }
+
+  if (session.step === STEPS.TYPE_SELECT) {
+    if (data === 'ds_t_rot') session.defectType = 'гнилой'
+    else if (data === 'ds_t_col') session.defectType = 'не тот цвет'
+    else { await ctx.answerCbQuery(); return true }
+
+    session.step = STEPS.CONFIRM
+    setSession(userId, session)
+
+    await ctx.answerCbQuery()
+    await ctx.editMessageText(formatSummary(session), {
+      parse_mode: 'Markdown',
+      reply_markup: {
+        inline_keyboard: [
+          [
+            { text: '✅ Подтвердить', callback_data: 'ds_yes' },
+            { text: '❌ Отменить', callback_data: 'ds_cancel' },
+          ],
+        ],
+      },
+    })
+    return true
+  }
+
+  if (session.step === STEPS.CONFIRM && data === 'ds_yes') {
+    await ctx.answerCbQuery()
+    await ctx.editMessageText('Сохраняю...')
+
+    try {
+      await saveDefect({
+        supplierId: session.supplierId,
+        flowerId: session.flowerId,
+        quantity: session.quantity,
+        defectType: session.defectType,
+      })
+    } catch (err) {
+      clearSession(userId)
+      await ctx.reply(`Ошибка сохранения: ${err.message}`)
+      return true
+    }
+
+    clearSession(userId)
+    const msg = session.defectType === 'гнилой'
+      ? '✅ Брак зафиксирован. Остаток уменьшен, движение «списание» записано.'
+      : '✅ Брак зафиксирован. Остаток не изменён, запись с пометкой добавлена.'
+    await ctx.editMessageText(msg)
+    return true
+  }
+
+  await ctx.answerCbQuery()
+  return true
+}
+
+// Обрабатывает ввод количества; возвращает true если обработал
+async function handleText(ctx) {
+  const userId = ctx.from.id
+  const session = getSession(userId)
+  if (!session) return false
+
+  if (session.step === STEPS.QUANTITY_INPUT) {
+    const qty = parseInt(ctx.message.text.trim(), 10)
+    if (isNaN(qty) || qty <= 0) {
+      await ctx.reply('Введи целое положительное число:')
+      return true
+    }
+
+    session.quantity = qty
+    session.step = STEPS.TYPE_SELECT
+    setSession(userId, session)
+
+    await ctx.reply('Тип брака:', {
+      reply_markup: {
+        inline_keyboard: [
+          [
+            { text: '🗑 Гнилые', callback_data: 'ds_t_rot' },
+            { text: '🎨 Не тот цвет', callback_data: 'ds_t_col' },
+          ],
+          [{ text: '❌ Отмена', callback_data: 'ds_cancel' }],
+        ],
+      },
+    })
+    return true
+  }
+
+  return false
+}
+
+module.exports = { startDefect, handleCallbackQuery, handleText, STEPS, getSession, clearSession }

--- a/bot/index.js
+++ b/bot/index.js
@@ -5,6 +5,7 @@ require('dotenv').config()
 const { Telegraf } = require('telegraf')
 const express = require('express')
 const delivery = require('./handlers/delivery')
+const defect = require('./handlers/defect')
 
 const BOT_TOKEN = process.env.BOT_TOKEN
 const ALLOWED_ID = Number(process.env.ALLOWED_TELEGRAM_ID)
@@ -28,7 +29,7 @@ bot.use((ctx, next) => {
 const MAIN_MENU = {
   reply_markup: {
     keyboard: [
-      ['📦 Поставка'],
+      ['📦 Поставка', '⚠️ Брак'],
       ['📋 Заказы', '🌸 Остатки'],
     ],
     resize_keyboard: true,
@@ -46,6 +47,7 @@ bot.help((ctx) => {
 
 // Кнопки главного меню
 bot.hears('📦 Поставка', (ctx) => delivery.startDelivery(ctx))
+bot.hears('⚠️ Брак', (ctx) => defect.startDefect(ctx))
 
 bot.hears('📋 Заказы', (ctx) => {
   ctx.reply('Раздел «Заказы» — в разработке.')
@@ -55,12 +57,19 @@ bot.hears('🌸 Остатки', (ctx) => {
   ctx.reply('Раздел «Остатки» — в разработке.')
 })
 
-// Callback-кнопки (inline keyboard)
-bot.on('callback_query', (ctx) => delivery.handleCallbackQuery(ctx))
+// Callback-кнопки (inline keyboard) — роутинг по префиксу
+bot.on('callback_query', async (ctx) => {
+  const data = ctx.callbackQuery.data
+  if (data.startsWith('ds_')) {
+    await defect.handleCallbackQuery(ctx)
+  } else {
+    await delivery.handleCallbackQuery(ctx)
+  }
+})
 
-// Текстовые сообщения — сначала пробуем диалог, иначе подсказка
+// Текстовые сообщения — сначала пробуем активные диалоги, иначе подсказка
 bot.on('text', async (ctx) => {
-  const handled = await delivery.handleText(ctx)
+  const handled = (await defect.handleText(ctx)) || (await delivery.handleText(ctx))
   if (!handled) {
     ctx.reply('Используй кнопки меню ниже.', MAIN_MENU)
   }

--- a/bot/lib/supabase.js
+++ b/bot/lib/supabase.js
@@ -95,4 +95,45 @@ async function saveDelivery({ supplierId, items, defectType, deliveredAt }) {
   return delivery.id
 }
 
-module.exports = { getSuppliers, createSupplier, getFlowers, saveDelivery }
+async function saveDefect({ supplierId, flowerId, quantity, defectType }) {
+  // Ищем последнюю партию этого цветка от этого поставщика
+  const { data: batch, error: batchErr } = await supabase
+    .from('batches')
+    .select('id')
+    .eq('flower_id', flowerId)
+    .eq('supplier_id', supplierId)
+    .order('delivered_at', { ascending: false })
+    .limit(1)
+    .single()
+
+  if (batchErr || !batch) {
+    throw new Error('Партия не найдена. Сначала зафиксируй поставку.')
+  }
+
+  const resolution = defectType === 'гнилой' ? 'возврат' : 'скидка'
+
+  const { data: defect, error: defectErr } = await supabase
+    .from('defects')
+    .insert({ batch_id: batch.id, flower_id: flowerId, quantity, defect_type: defectType, resolution })
+    .select('id')
+    .single()
+  if (defectErr) throw defectErr
+
+  // Гнилые → уменьшаем остаток (движение «списание»)
+  if (defectType === 'гнилой') {
+    const { error: movErr } = await supabase
+      .from('movements')
+      .insert({
+        flower_id: flowerId,
+        batch_id: batch.id,
+        defect_id: defect.id,
+        movement_type: 'списание',
+        quantity,
+      })
+    if (movErr) throw movErr
+  }
+
+  return defect.id
+}
+
+module.exports = { getSuppliers, createSupplier, getFlowers, saveDelivery, saveDefect }

--- a/bot/package.json
+++ b/bot/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "node --watch index.js",
-    "test": "node --test test/smoke.test.js test/delivery.test.js"
+    "test": "node --test test/smoke.test.js test/delivery.test.js test/defect.test.js"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.0",

--- a/bot/test/defect.test.js
+++ b/bot/test/defect.test.js
@@ -1,0 +1,238 @@
+'use strict'
+
+const { describe, it, beforeEach } = require('node:test')
+const assert = require('node:assert/strict')
+
+const mockSuppliers = [
+  { id: 'sup-1', name: 'Роза Маркет', phone: '+7999' },
+  { id: 'sup-2', name: 'Тюльпан Опт', phone: null },
+]
+const mockFlowers = [
+  { id: 'fl-1', name: 'Роза' },
+  { id: 'fl-2', name: 'Тюльпан' },
+]
+
+function makeSession(overrides = {}) {
+  return {
+    step: 'SUPPLIER_SELECT',
+    supplierId: null,
+    supplierName: null,
+    flowerId: null,
+    flowerName: null,
+    quantity: null,
+    defectType: null,
+    suppliers: [...mockSuppliers],
+    flowers: [...mockFlowers],
+    ...overrides,
+  }
+}
+
+function formatSummary(session) {
+  const typeLabel = session.defectType === 'гнилой' ? '🗑 Гнилые' : '🎨 Не тот цвет'
+  const action = session.defectType === 'гнилой'
+    ? 'Остаток уменьшится, движение «списание» запишется'
+    : 'Остаток не изменится, запись с пометкой добавится'
+  return (
+    `⚠️ *Брак — подтверждение*\n\n` +
+    `Поставщик: ${session.supplierName}\n` +
+    `Цветок: ${session.flowerName}\n` +
+    `Количество: ${session.quantity} шт.\n` +
+    `Тип: ${typeLabel}\n\n` +
+    `_${action}_`
+  )
+}
+
+// ─── callback_data длина ──────────────────────────────────────────
+
+describe('callback_data не превышает 64 байта', () => {
+  const uuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' // 36 символов
+
+  it('ds_s_ + UUID', () => {
+    const data = `ds_s_${uuid}`
+    assert.ok(Buffer.byteLength(data) <= 64, `длина ${Buffer.byteLength(data)}`)
+  })
+
+  it('ds_f_ + UUID', () => {
+    const data = `ds_f_${uuid}`
+    assert.ok(Buffer.byteLength(data) <= 64, `длина ${Buffer.byteLength(data)}`)
+  })
+
+  it('ds_t_rot', () => {
+    assert.ok(Buffer.byteLength('ds_t_rot') <= 64)
+  })
+
+  it('ds_t_col', () => {
+    assert.ok(Buffer.byteLength('ds_t_col') <= 64)
+  })
+
+  it('ds_yes', () => {
+    assert.ok(Buffer.byteLength('ds_yes') <= 64)
+  })
+
+  it('ds_cancel', () => {
+    assert.ok(Buffer.byteLength('ds_cancel') <= 64)
+  })
+})
+
+// ─── Форматирование итога ─────────────────────────────────────────
+
+describe('formatSummary — гнилые', () => {
+  it('показывает тип «Гнилые» и предупреждение об уменьшении остатка', () => {
+    const session = makeSession({
+      supplierName: 'Роза Маркет',
+      flowerName: 'Роза',
+      quantity: 10,
+      defectType: 'гнилой',
+    })
+    const text = formatSummary(session)
+    assert.ok(text.includes('🗑 Гнилые'))
+    assert.ok(text.includes('Остаток уменьшится'))
+    assert.ok(text.includes('списание'))
+    assert.ok(text.includes('10 шт.'))
+    assert.ok(text.includes('Роза Маркет'))
+  })
+})
+
+describe('formatSummary — не тот цвет', () => {
+  it('показывает тип «Не тот цвет» и что остаток не изменится', () => {
+    const session = makeSession({
+      supplierName: 'Тюльпан Опт',
+      flowerName: 'Тюльпан',
+      quantity: 5,
+      defectType: 'не тот цвет',
+    })
+    const text = formatSummary(session)
+    assert.ok(text.includes('🎨 Не тот цвет'))
+    assert.ok(text.includes('Остаток не изменится'))
+    assert.ok(text.includes('5 шт.'))
+  })
+})
+
+// ─── Логика состояний ────────────────────────────────────────────
+
+describe('Переходы состояний диалога брака', () => {
+  const sessions = new Map()
+  function getSession(id) { return sessions.get(id) }
+  function setSession(id, data) { sessions.set(id, data) }
+  function clearSession(id) { sessions.delete(id) }
+
+  beforeEach(() => sessions.clear())
+
+  it('переход SUPPLIER_SELECT → FLOWER_SELECT', () => {
+    const session = makeSession()
+    const id = 'sup-1'
+    const supplier = session.suppliers.find((s) => s.id === id)
+    session.supplierId = id
+    session.supplierName = supplier.name
+    session.step = 'FLOWER_SELECT'
+    setSession(1, session)
+
+    const s = getSession(1)
+    assert.equal(s.step, 'FLOWER_SELECT')
+    assert.equal(s.supplierName, 'Роза Маркет')
+  })
+
+  it('переход FLOWER_SELECT → QUANTITY_INPUT', () => {
+    const session = makeSession({ step: 'FLOWER_SELECT', supplierId: 'sup-1', supplierName: 'Роза Маркет' })
+    session.flowerId = 'fl-1'
+    session.flowerName = 'Роза'
+    session.step = 'QUANTITY_INPUT'
+    setSession(1, session)
+
+    const s = getSession(1)
+    assert.equal(s.step, 'QUANTITY_INPUT')
+    assert.equal(s.flowerName, 'Роза')
+  })
+
+  it('переход QUANTITY_INPUT → TYPE_SELECT при валидном числе', () => {
+    const session = makeSession({ step: 'QUANTITY_INPUT', flowerId: 'fl-1', flowerName: 'Роза' })
+    const qty = parseInt('7', 10)
+    assert.ok(!isNaN(qty) && qty > 0)
+    session.quantity = qty
+    session.step = 'TYPE_SELECT'
+    setSession(1, session)
+
+    const s = getSession(1)
+    assert.equal(s.step, 'TYPE_SELECT')
+    assert.equal(s.quantity, 7)
+  })
+
+  it('переход TYPE_SELECT → CONFIRM (гнилые)', () => {
+    const session = makeSession({ step: 'TYPE_SELECT', quantity: 7, flowerName: 'Роза', supplierName: 'Роза Маркет' })
+    session.defectType = 'гнилой'
+    session.step = 'CONFIRM'
+    setSession(1, session)
+
+    const s = getSession(1)
+    assert.equal(s.step, 'CONFIRM')
+    assert.equal(s.defectType, 'гнилой')
+  })
+
+  it('переход TYPE_SELECT → CONFIRM (не тот цвет)', () => {
+    const session = makeSession({ step: 'TYPE_SELECT', quantity: 3, flowerName: 'Тюльпан', supplierName: 'Тюльпан Опт' })
+    session.defectType = 'не тот цвет'
+    session.step = 'CONFIRM'
+    setSession(1, session)
+
+    assert.equal(getSession(1).defectType, 'не тот цвет')
+  })
+
+  it('отмена очищает сессию', () => {
+    setSession(1, makeSession())
+    clearSession(1)
+    assert.equal(getSession(1), undefined)
+  })
+})
+
+// ─── saveDefect — юнит ───────────────────────────────────────────
+
+describe('saveDefect — гнилые: создаёт defect + движение «списание»', () => {
+  it('вызывается с defect_type=гнилой и movement_type=списание', async () => {
+    const calls = []
+
+    const mockSaveDefect = async ({ supplierId, flowerId, quantity, defectType }) => {
+      // Имитация: находим партию
+      const batchId = 'batch-1'
+      const resolution = defectType === 'гнилой' ? 'возврат' : 'скидка'
+      calls.push({ supplierId, flowerId, quantity, defectType, batchId, resolution })
+
+      // Гнилые → списание
+      if (defectType === 'гнилой') {
+        calls.push({ movement_type: 'списание', quantity })
+      }
+
+      return 'defect-id-1'
+    }
+
+    await mockSaveDefect({ supplierId: 'sup-1', flowerId: 'fl-1', quantity: 10, defectType: 'гнилой' })
+
+    assert.equal(calls.length, 2)
+    assert.equal(calls[0].defectType, 'гнилой')
+    assert.equal(calls[0].resolution, 'возврат')
+    assert.equal(calls[1].movement_type, 'списание')
+    assert.equal(calls[1].quantity, 10)
+  })
+})
+
+describe('saveDefect — не тот цвет: только defect, без движения', () => {
+  it('вызывается с defect_type=не тот цвет, движение не создаётся', async () => {
+    const calls = []
+
+    const mockSaveDefect = async ({ supplierId, flowerId, quantity, defectType }) => {
+      const resolution = defectType === 'гнилой' ? 'возврат' : 'скидка'
+      calls.push({ supplierId, flowerId, quantity, defectType, resolution })
+
+      if (defectType === 'гнилой') {
+        calls.push({ movement_type: 'списание', quantity })
+      }
+
+      return 'defect-id-2'
+    }
+
+    await mockSaveDefect({ supplierId: 'sup-2', flowerId: 'fl-2', quantity: 5, defectType: 'не тот цвет' })
+
+    assert.equal(calls.length, 1, 'только одна запись — defect, без движения')
+    assert.equal(calls[0].defectType, 'не тот цвет')
+    assert.equal(calls[0].resolution, 'скидка')
+  })
+})


### PR DESCRIPTION
- handlers/defect.js: пошаговый диалог (поставщик → цветок → кол-во → тип → подтверждение)
- lib/supabase.js: saveDefect — запись в defects; гнилые → движение «списание», не тот цвет → только пометка
- index.js: кнопка «⚠️ Брак» в меню, роутинг callback_query по префиксу ds_
- test/defect.test.js: 12 тестов, оба типа брака, callback_data ≤ 64 байта