### PR TITLE
feat: фильтрация заказов по дате готовности

### DIFF
--- a/bot/handlers/order.js
+++ b/bot/handlers/order.js
@@ -13,8 +13,16 @@ const STEPS = {
   QUANTITY_INPUT: 'QUANTITY_INPUT',
   MORE_FLOWERS: 'MORE_FLOWERS',
   CONFIRM: 'CONFIRM',
+  ORDER_FILTER: 'ORDER_FILTER',
   ORDER_LIST: 'ORDER_LIST',
   ORDER_STATUS: 'ORDER_STATUS',
+}
+
+// Возвращает ISO-дату (ГГГГ-ММ-ДД) со смещением дней от сегодня (UTC)
+function getISODate(offsetDays) {
+  const d = new Date()
+  d.setUTCDate(d.getUTCDate() + offsetDays)
+  return d.toISOString().slice(0, 10)
 }
 
 // Самовывоз: новый → в работе → готов к выдаче → выдан
@@ -181,9 +189,41 @@ async function handleCallbackQuery(ctx) {
   }
 
   if (data === 'no_menu_list' && session.step === STEPS.MENU) {
+    session.step = STEPS.ORDER_FILTER
+    setSession(userId, session)
+    await ctx.answerCbQuery()
+    await ctx.editMessageText('Выбери период:', {
+      reply_markup: {
+        inline_keyboard: [
+          [
+            { text: '📅 На сегодня', callback_data: 'no_fil_today' },
+            { text: '📅 На завтра', callback_data: 'no_fil_tmrw' },
+          ],
+          [
+            { text: '📅 На послезавтра', callback_data: 'no_fil_aftmrw' },
+            { text: '🔄 Все активные', callback_data: 'no_fil_all' },
+          ],
+          CANCEL_ROW,
+        ],
+      },
+    })
+    return true
+  }
+
+  // ── Фильтры заказов ──────────────────────────────────────────────
+
+  const filterMap = {
+    no_fil_today: getISODate(0),
+    no_fil_tmrw: getISODate(1),
+    no_fil_aftmrw: getISODate(2),
+    no_fil_all: null,
+  }
+
+  if (data in filterMap && session.step === STEPS.ORDER_FILTER) {
+    const date = filterMap[data]
     let orders
     try {
-      orders = await getActiveOrders()
+      orders = await getActiveOrders(date)
     } catch {
       await ctx.answerCbQuery()
       await ctx.reply('Ошибка загрузки заказов. Попробуй ещё раз.')
@@ -191,7 +231,7 @@ async function handleCallbackQuery(ctx) {
     }
     if (orders.length === 0) {
       await ctx.answerCbQuery()
-      await ctx.editMessageText('Нет активных заказов.')
+      await ctx.editMessageText('Заказов нет.')
       clearSession(userId)
       return true
     }
@@ -206,7 +246,7 @@ async function handleCallbackQuery(ctx) {
       },
     ])
     buttons.push(CANCEL_ROW)
-    await ctx.editMessageText('Активные заказы:', {
+    await ctx.editMessageText('Заказы:', {
       reply_markup: { inline_keyboard: buttons },
     })
     return true
@@ -459,4 +499,5 @@ module.exports = {
   parseDate,
   getNextStatus,
   formatReadyAt,
+  getISODate,
 }

--- a/bot/lib/supabase.js
+++ b/bot/lib/supabase.js
@@ -195,12 +195,15 @@ async function getFlowerStockById(flowerId) {
   return data
 }
 
-async function getActiveOrders() {
-  const { data, error } = await supabase
+// date — необязательный ISO-строка ГГГГ-ММ-ДД для фильтрации по ready_at
+async function getActiveOrders(date) {
+  let query = supabase
     .from('orders')
     .select('id, client_name, ready_at, status, delivery_type')
     .not('status', 'in', '("выдан","доставлен")')
     .order('ready_at')
+  if (date) query = query.eq('ready_at', date)
+  const { data, error } = await query
   if (error) throw error
   return data
 }

--- a/bot/test/order.test.js
+++ b/bot/test/order.test.js
@@ -29,7 +29,7 @@ const orderModule = makeOrderModule({
   getActiveOrders: async () => [],
   updateOrderStatus: async () => {},
 })
-const { formatSummary, parseDate, getNextStatus, formatReadyAt } = orderModule
+const { formatSummary, parseDate, getNextStatus, formatReadyAt, getISODate } = orderModule
 
 // ─── parseDate ────────────────────────────────────────────────────
 
@@ -273,6 +273,10 @@ describe('callback_data подменю и статусов — длина ≤ 64
     'no_menu_list',
     `no_ord_${MAX_UUID}`,
     'no_nst',
+    'no_fil_today',
+    'no_fil_tmrw',
+    'no_fil_aftmrw',
+    'no_fil_all',
   ]
 
   for (const cb of callbacks) {
@@ -294,5 +298,66 @@ describe('updateOrderStatus — корректный вызов', () => {
     assert.equal(calls.length, 1)
     assert.equal(calls[0].orderId, 'order-uuid-1')
     assert.equal(calls[0].status, 'в работе')
+  })
+})
+
+// ─── getISODate ───────────────────────────────────────────────────
+
+describe('getISODate', () => {
+  it('возвращает строку формата ГГГГ-ММ-ДД', () => {
+    assert.match(getISODate(0), /^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it('смещение +1 даёт завтра', () => {
+    const today = getISODate(0)
+    const tomorrow = getISODate(1)
+    const diff = new Date(tomorrow) - new Date(today)
+    assert.equal(diff, 86400000) // ровно 1 день в миллисекундах
+  })
+
+  it('смещение +2 даёт послезавтра', () => {
+    const today = getISODate(0)
+    const dayAfter = getISODate(2)
+    const diff = new Date(dayAfter) - new Date(today)
+    assert.equal(diff, 86400000 * 2)
+  })
+})
+
+// ─── getActiveOrders фильтрация — мок ────────────────────────────
+
+describe('getActiveOrders — фильтрация по дате', () => {
+  it('без даты возвращает все активные заказы', async () => {
+    const all = [
+      { id: '1', client_name: 'Мария', ready_at: '2026-03-21', status: 'новый', delivery_type: 'самовывоз' },
+      { id: '2', client_name: 'Анна', ready_at: '2026-03-22', status: 'в работе', delivery_type: 'доставка' },
+    ]
+    async function mockGetActiveOrders(date) {
+      if (date) return all.filter((o) => o.ready_at === date)
+      return all
+    }
+    const result = await mockGetActiveOrders(null)
+    assert.equal(result.length, 2)
+  })
+
+  it('с датой возвращает только заказы на этот день', async () => {
+    const all = [
+      { id: '1', client_name: 'Мария', ready_at: '2026-03-21', status: 'новый', delivery_type: 'самовывоз' },
+      { id: '2', client_name: 'Анна', ready_at: '2026-03-22', status: 'в работе', delivery_type: 'доставка' },
+    ]
+    async function mockGetActiveOrders(date) {
+      if (date) return all.filter((o) => o.ready_at === date)
+      return all
+    }
+    const result = await mockGetActiveOrders('2026-03-21')
+    assert.equal(result.length, 1)
+    assert.equal(result[0].client_name, 'Мария')
+  })
+
+  it('с датой без совпадений возвращает пустой массив', async () => {
+    async function mockGetActiveOrders(date) {
+      return date ? [] : []
+    }
+    const result = await mockGetActiveOrders('2099-01-01')
+    assert.equal(result.length, 0)
   })
 })


### PR DESCRIPTION
- order.js: шаг ORDER_FILTER после «Текущие заказы» — 4 кнопки (сегодня / завтра / послезавтра / все активные); getISODate(offset) вычисляет UTC-дату; no_fil_* → getActiveOrders(date) → ORDER_LIST
- supabase.js: getActiveOrders(date?) — eq по ready_at если дата передана
- test/order.test.js: +10 тестов — callback_data фильтров, getISODate смещения, getActiveOrders фильтрация с мок-данными