### PR TITLE
feat(#25): валидация количества цветов при создании заказа

### DIFF
--- a/src/hooks/useNewOrder.js
+++ b/src/hooks/useNewOrder.js
@@ -2,6 +2,22 @@ import { supabase } from '../lib/supabase'
 
 export function useNewOrder() {
   async function saveOrder({ clientName, clientPhone, readyAt, deliveryType, address, items }) {
+    // Повторная проверка остатков перед записью
+    const flowerIds = items.map((i) => i.flowerId)
+    const { data: stock, error: stockErr } = await supabase
+      .from('flower_stock')
+      .select('flower_id, name, available')
+      .in('flower_id', flowerIds)
+    if (stockErr) throw stockErr
+    for (const item of items) {
+      const s = stock?.find((s) => s.flower_id === item.flowerId)
+      if (!s || item.quantity > s.available) {
+        const name = s?.name ?? 'цветка'
+        const avail = s?.available ?? 0
+        throw new Error(`На складе только ${avail} ${name.toLowerCase()}`)
+      }
+    }
+
     const { data: order, error: orderErr } = await supabase
       .from('orders')
       .insert({

--- a/src/pages/NewOrderPage.jsx
+++ b/src/pages/NewOrderPage.jsx
@@ -39,6 +39,15 @@ export default function NewOrderPage({ onBack }) {
     return f ? f.available : 0
   }
 
+  function itemError(item) {
+    if (!item.flowerId || !item.quantity) return null
+    const qty = Number(item.quantity)
+    if (qty <= 0) return null
+    const f = availableFlowers.find((f) => f.flower_id === item.flowerId)
+    if (!f || qty <= f.available) return null
+    return `На складе только ${f.available} ${f.name.toLowerCase()}`
+  }
+
   const isValid =
     clientName.trim() &&
     readyAt &&
@@ -153,6 +162,7 @@ export default function NewOrderPage({ onBack }) {
 
       {items.map((item, idx) => {
         const max = maxQty(item.flowerId)
+        const err = itemError(item)
         return (
           <div key={item.id} className="bg-white rounded-xl p-4 shadow-sm space-y-3">
             <div className="flex items-center justify-between">
@@ -188,8 +198,9 @@ export default function NewOrderPage({ onBack }) {
               value={item.quantity}
               onChange={(e) => updateItem(item.id, { quantity: e.target.value })}
               required
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+              className={`w-full border rounded-lg px-3 py-2 text-sm ${err ? 'border-red-400' : 'border-gray-300'}`}
             />
+            {err && <p className="text-red-500 text-xs">{err}</p>}
           </div>
         )
       })}

--- a/src/tests/NewOrderPage.test.jsx
+++ b/src/tests/NewOrderPage.test.jsx
@@ -94,6 +94,38 @@ describe('NewOrderPage', () => {
     expect(screen.getAllByText(/позиция/i)).toHaveLength(1)
   })
 
+  it('показывает ошибку когда количество превышает остаток', () => {
+    setup()
+    render(<NewOrderPage />)
+    const flowerSelects = screen.getAllByRole('combobox')
+    const flowerSelect = flowerSelects[flowerSelects.length - 1]
+    fireEvent.change(flowerSelect, { target: { value: '1' } }) // Роза, available: 8
+    fireEvent.change(screen.getByPlaceholderText(/количество/i), { target: { value: '9' } })
+    expect(screen.getByText(/на складе только 8/i)).toBeDefined()
+  })
+
+  it('содержит название цветка в сообщении об ошибке', () => {
+    setup()
+    render(<NewOrderPage />)
+    const flowerSelects = screen.getAllByRole('combobox')
+    const flowerSelect = flowerSelects[flowerSelects.length - 1]
+    fireEvent.change(flowerSelect, { target: { value: '1' } })
+    fireEvent.change(screen.getByPlaceholderText(/количество/i), { target: { value: '100' } })
+    expect(screen.getByText(/на складе только.*роза/i)).toBeDefined()
+  })
+
+  it('кнопка «Сохранить» заблокирована когда количество превышает остаток', () => {
+    setup()
+    render(<NewOrderPage />)
+    fillBaseForm()
+    const flowerSelects = screen.getAllByRole('combobox')
+    const flowerSelect = flowerSelects[flowerSelects.length - 1]
+    fireEvent.change(flowerSelect, { target: { value: '1' } })
+    fireEvent.change(screen.getByPlaceholderText(/количество/i), { target: { value: '100' } })
+    const btn = screen.getByRole('button', { name: /сохранить заказ/i })
+    expect(btn.disabled).toBe(true)
+  })
+
   it('кнопка «Сохранить» заблокирована при пустой форме', () => {
     setup()
     render(<NewOrderPage />)

--- a/src/tests/useNewOrder.test.js
+++ b/src/tests/useNewOrder.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useNewOrder } from '../hooks/useNewOrder'
+
+vi.mock('../lib/supabase', () => {
+  const chain = {
+    from: vi.fn(),
+    select: vi.fn(),
+    insert: vi.fn(),
+    in: vi.fn(),
+    single: vi.fn(),
+  }
+  // make every method return chain for chaining
+  Object.keys(chain).forEach((k) => chain[k].mockReturnValue(chain))
+  return { supabase: chain }
+})
+
+import { supabase } from '../lib/supabase'
+
+const baseOrder = {
+  clientName: 'Анна',
+  clientPhone: null,
+  readyAt: '2026-03-25',
+  deliveryType: 'самовывоз',
+  address: '',
+  items: [{ flowerId: 'f1', quantity: 3 }],
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  supabase.from.mockReturnValue(supabase)
+  supabase.select.mockReturnValue(supabase)
+  supabase.insert.mockReturnValue(supabase)
+  supabase.in.mockReturnValue(supabase)
+  supabase.single.mockReturnValue(supabase)
+})
+
+describe('useNewOrder — pre-check', () => {
+  it('бросает ошибку если quantity > available', async () => {
+    // pre-check stock fetch returns insufficient stock
+    supabase.in.mockResolvedValueOnce({
+      data: [{ flower_id: 'f1', name: 'Роза', available: 2 }],
+      error: null,
+    })
+
+    const { result } = renderHook(() => useNewOrder())
+    await expect(result.current.saveOrder(baseOrder)).rejects.toThrow('На складе только 2 роза')
+  })
+
+  it('сообщение об ошибке содержит количество и название', async () => {
+    supabase.in.mockResolvedValueOnce({
+      data: [{ flower_id: 'f1', name: 'Тюльпан', available: 1 }],
+      error: null,
+    })
+
+    const { result } = renderHook(() => useNewOrder())
+    await expect(result.current.saveOrder(baseOrder)).rejects.toThrow('На складе только 1')
+  })
+
+  it('бросает ошибку если цветок не найден в stock', async () => {
+    supabase.in.mockResolvedValueOnce({ data: [], error: null })
+
+    const { result } = renderHook(() => useNewOrder())
+    await expect(result.current.saveOrder(baseOrder)).rejects.toThrow('На складе только 0')
+  })
+})


### PR DESCRIPTION
- itemError() в NewOrderPage: inline-сообщение «На складе только N name» при quantity > available; красная рамка на поле ввода
- isValid уже блокировал кнопку — теперь пользователь видит причину
- useNewOrder: pre-check к flower_stock перед INSERT в Supabase (защита от гонки — если stock изменился после UI-проверки)
- тесты: 3 новых кейса в NewOrderPage.test + useNewOrder.test.js (3 теста)