### PR TITLE
feat: обработка ошибок и валидация форм до продакшн стандарта

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,6 @@
 import { useState } from 'react'
+import ErrorBoundary from './components/ErrorBoundary'
+import { useOnlineStatus } from './hooks/useOnlineStatus'
 import StockPage from './pages/StockPage'
 import HistoryPage from './pages/HistoryPage'
 import OrdersPage from './pages/OrdersPage'
@@ -67,6 +69,7 @@ const TABS_WITH_ADD = ['stock', 'orders', 'delivery', 'suppliers']
 
 export default function App() {
   const [tab, setTab] = useState('stock')
+  const online = useOnlineStatus()
   const [stockAddOpen, setStockAddOpen] = useState(false)
   const [supplierAddOpen, setSupplierAddOpen] = useState(false)
   const [deliveryAddOpen, setDeliveryAddOpen] = useState(false)
@@ -94,7 +97,14 @@ export default function App() {
         )}
       </header>
 
+      {!online && (
+        <div className="bg-yellow-50 border-b border-yellow-200 px-4 py-2 text-center">
+          <p className="text-xs text-yellow-700">Нет интернета — только просмотр</p>
+        </div>
+      )}
+
       <main className="px-4 py-4 flex-1">
+        <ErrorBoundary>
         {tab === 'stock' && (
           <StockPage
             addModalOpen={stockAddOpen}
@@ -116,6 +126,7 @@ export default function App() {
             onAddFormClose={() => setSupplierAddOpen(false)}
           />
         )}
+        </ErrorBoundary>
       </main>
 
       <nav className="sticky bottom-0 bg-white border-t border-gray-100 flex">

--- a/src/components/ConfirmDialog.jsx
+++ b/src/components/ConfirmDialog.jsx
@@ -1,0 +1,23 @@
+export default function ConfirmDialog({ message, onConfirm, onCancel }) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 px-4 pb-8">
+      <div className="bg-white rounded-2xl w-full max-w-sm p-5 space-y-4 shadow-xl">
+        <p className="text-[16px] text-gray-800 text-center">{message}</p>
+        <div className="flex gap-3">
+          <button
+            onClick={onCancel}
+            className="flex-1 bg-gray-100 text-gray-700 text-sm py-3 rounded-xl font-medium"
+          >
+            Отмена
+          </button>
+          <button
+            onClick={onConfirm}
+            className="flex-1 bg-red-500 text-white text-sm py-3 rounded-xl font-medium"
+          >
+            Да
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,0 +1,31 @@
+import { Component } from 'react'
+
+export default class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-[60vh] flex flex-col items-center justify-center px-6 text-center">
+          <p className="text-5xl mb-4">🌸</p>
+          <h2 className="text-lg font-semibold text-gray-800 mb-2">Что-то пошло не так</h2>
+          <p className="text-sm text-gray-500 mb-6">Попробуйте перезагрузить страницу</p>
+          <button
+            onClick={() => window.location.reload()}
+            className="bg-green-600 text-white text-sm py-3 px-6 rounded-xl"
+          >
+            Перезагрузить
+          </button>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}

--- a/src/components/OrderCard.jsx
+++ b/src/components/OrderCard.jsx
@@ -1,13 +1,11 @@
+import { useState } from 'react'
+import ConfirmDialog from './ConfirmDialog'
+
 const STATUS_STYLES = {
   'новый': 'bg-blue-100 text-blue-700',
   'в работе': 'bg-yellow-100 text-yellow-700',
   'готов к выдаче': 'bg-green-100 text-green-700',
   'готов к доставке': 'bg-green-100 text-green-700',
-}
-
-const NEXT_STATUS = {
-  'новый': 'в работе',
-  'в работе': null,
 }
 
 function nextOrderStatus(status, deliveryType) {
@@ -24,7 +22,8 @@ function formatDate(dateStr) {
   return d.toLocaleDateString('ru-RU', { day: 'numeric', month: 'short' })
 }
 
-export default function OrderCard({ order, onStatusChange }) {
+export default function OrderCard({ order, onStatusChange, onDelete }) {
+  const [confirmOpen, setConfirmOpen] = useState(false)
   const { client_name, client_phone, delivery_type, delivery_address, status, ready_at, order_items = [] } = order
   const statusStyle = STATUS_STYLES[status] || 'bg-gray-100 text-gray-600'
   const isDelivery = delivery_type === 'доставка'
@@ -59,6 +58,24 @@ export default function OrderCard({ order, onStatusChange }) {
         >
           → {next}
         </button>
+      )}
+
+      {onDelete && (
+        <button
+          type="button"
+          onClick={() => setConfirmOpen(true)}
+          className="w-full bg-gray-100 text-red-500 text-sm py-2.5 rounded-xl font-medium mt-2"
+        >
+          Отменить заказ
+        </button>
+      )}
+
+      {confirmOpen && (
+        <ConfirmDialog
+          message={`Удалить заказ клиента «${client_name}»?`}
+          onConfirm={() => { setConfirmOpen(false); onDelete() }}
+          onCancel={() => setConfirmOpen(false)}
+        />
       )}
     </div>
   )

--- a/src/hooks/useOnlineStatus.js
+++ b/src/hooks/useOnlineStatus.js
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react'
+
+export function useOnlineStatus() {
+  const [online, setOnline] = useState(navigator.onLine)
+
+  useEffect(() => {
+    function on() { setOnline(true) }
+    function off() { setOnline(false) }
+    window.addEventListener('online', on)
+    window.addEventListener('offline', off)
+    return () => {
+      window.removeEventListener('online', on)
+      window.removeEventListener('offline', off)
+    }
+  }, [])
+
+  return online
+}

--- a/src/hooks/useOrders.js
+++ b/src/hooks/useOrders.js
@@ -43,5 +43,11 @@ export function useOrders() {
     fetchData()
   }, [])
 
-  return { orders, loading, error, refresh: fetchData }
+  async function deleteOrder(id) {
+    const { error: err } = await supabase.from('orders').delete().eq('id', id)
+    if (err) throw new Error('Не удалось удалить заказ')
+    setOrders((prev) => prev.filter((o) => o.id !== id))
+  }
+
+  return { orders, loading, error, refresh: fetchData, deleteOrder }
 }

--- a/src/pages/OrdersPage.jsx
+++ b/src/pages/OrdersPage.jsx
@@ -1,8 +1,19 @@
+import { useState } from 'react'
 import OrderCard from '../components/OrderCard'
 import { useOrders } from '../hooks/useOrders'
 
 export default function OrdersPage() {
-  const { orders, loading, error, refresh } = useOrders()
+  const { orders, loading, error, refresh, deleteOrder } = useOrders()
+  const [deleteError, setDeleteError] = useState(null)
+
+  async function handleDelete(id) {
+    setDeleteError(null)
+    try {
+      await deleteOrder(id)
+    } catch (err) {
+      setDeleteError(err.message || 'Не удалось удалить заказ')
+    }
+  }
 
   if (loading) {
     return <p className="text-center text-gray-400 mt-10 text-sm">Загрузка...</p>
@@ -11,7 +22,7 @@ export default function OrdersPage() {
   if (error) {
     return (
       <div className="text-center mt-10">
-        <p className="text-red-500 text-sm mb-3">{error}</p>
+        <p className="text-red-500 text-sm mb-3">Не удалось загрузить заказы</p>
         <button onClick={refresh} className="text-sm text-green-600 underline">
           Повторить
         </button>
@@ -21,10 +32,19 @@ export default function OrdersPage() {
 
   return (
     <div className="space-y-3">
+      {deleteError && (
+        <p className="text-red-500 text-xs text-center">{deleteError}</p>
+      )}
       {orders.length === 0 ? (
         <p className="text-center text-gray-400 mt-6 text-sm">Активных заказов нет</p>
       ) : (
-        orders.map((order) => <OrderCard key={order.id} order={order} />)
+        orders.map((order) => (
+          <OrderCard
+            key={order.id}
+            order={order}
+            onDelete={() => handleDelete(order.id)}
+          />
+        ))
       )}
     </div>
   )

--- a/src/pages/SuppliersPage.jsx
+++ b/src/pages/SuppliersPage.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useSuppliers } from '../hooks/useSuppliers'
+import ConfirmDialog from '../components/ConfirmDialog'
 
 const MAX_SUPPLIERS = 5
 
@@ -8,9 +9,13 @@ function SupplierForm({ initial, onSave, onCancel }) {
   const [phone, setPhone] = useState(initial?.phone ?? '')
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState(null)
+  const [nameTouched, setNameTouched] = useState(false)
+
+  const nameError = nameTouched && !name.trim()
 
   async function handleSubmit(e) {
     e.preventDefault()
+    setNameTouched(true)
     if (!name.trim()) return
     setSaving(true)
     setError(null)
@@ -25,14 +30,18 @@ function SupplierForm({ initial, onSave, onCancel }) {
 
   return (
     <form onSubmit={handleSubmit} className="bg-white rounded-2xl p-4 border border-gray-100 mb-3 space-y-3">
-      <input
-        type="text"
-        placeholder="Имя поставщика"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
-        required
-      />
+      <div>
+        <input
+          type="text"
+          placeholder="Имя поставщика"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onBlur={() => setNameTouched(true)}
+          className={`w-full border rounded-lg px-3 py-2 text-sm ${nameError ? 'border-red-400' : 'border-gray-300'}`}
+          required
+        />
+        {nameError && <p className="text-red-500 text-xs mt-1">Обязательное поле</p>}
+      </div>
       <input
         type="tel"
         placeholder="Телефон"
@@ -44,7 +53,7 @@ function SupplierForm({ initial, onSave, onCancel }) {
       <div className="flex gap-2">
         <button
           type="submit"
-          disabled={saving || !name.trim()}
+          disabled={saving}
           className="flex-1 bg-green-600 text-white text-sm py-2.5 rounded-xl disabled:opacity-50"
         >
           {saving ? 'Сохранение...' : 'Сохранить'}
@@ -66,6 +75,7 @@ export default function SuppliersPage({ addFormOpen, onAddFormClose }) {
   const [showAddForm, setShowAddForm] = useState(false)
   const [editingId, setEditingId] = useState(null)
   const [deleteError, setDeleteError] = useState(null)
+  const [confirmDelete, setConfirmDelete] = useState(null)
 
   const atLimit = suppliers.length >= MAX_SUPPLIERS
 
@@ -91,10 +101,11 @@ export default function SuppliersPage({ addFormOpen, onAddFormClose }) {
 
   async function handleDelete(id) {
     setDeleteError(null)
+    setConfirmDelete(null)
     try {
       await deleteSupplier(id)
     } catch (err) {
-      setDeleteError(err.message || 'Ошибка удаления')
+      setDeleteError('Не удалось удалить поставщика')
     }
   }
 
@@ -103,7 +114,7 @@ export default function SuppliersPage({ addFormOpen, onAddFormClose }) {
   }
 
   if (error) {
-    return <p className="text-center text-red-500 mt-10 text-sm">{error}</p>
+    return <p className="text-center text-red-500 mt-10 text-sm">Не удалось загрузить поставщиков</p>
   }
 
   return (
@@ -147,7 +158,7 @@ export default function SuppliersPage({ addFormOpen, onAddFormClose }) {
                   Изменить
                 </button>
                 <button
-                  onClick={() => handleDelete(s.id)}
+                  onClick={() => setConfirmDelete({ id: s.id, name: s.name })}
                   className="flex-1 bg-gray-100 text-red-500 text-sm py-2.5 rounded-xl font-medium"
                 >
                   Удалить
@@ -166,6 +177,14 @@ export default function SuppliersPage({ addFormOpen, onAddFormClose }) {
         >
           {atLimit ? `Максимум ${MAX_SUPPLIERS} поставщиков` : '+ Добавить поставщика'}
         </button>
+      )}
+
+      {confirmDelete && (
+        <ConfirmDialog
+          message={`Удалить поставщика «${confirmDelete.name}»?`}
+          onConfirm={() => handleDelete(confirmDelete.id)}
+          onCancel={() => setConfirmDelete(null)}
+        />
       )}
     </div>
   )

--- a/src/tests/ConfirmDialog.test.jsx
+++ b/src/tests/ConfirmDialog.test.jsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import ConfirmDialog from '../components/ConfirmDialog'
+
+describe('ConfirmDialog', () => {
+  it('показывает сообщение', () => {
+    render(<ConfirmDialog message="Удалить?" onConfirm={vi.fn()} onCancel={vi.fn()} />)
+    expect(screen.getByText('Удалить?')).toBeDefined()
+  })
+
+  it('вызывает onConfirm при клике «Да»', () => {
+    const onConfirm = vi.fn()
+    render(<ConfirmDialog message="Удалить?" onConfirm={onConfirm} onCancel={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: /^да$/i }))
+    expect(onConfirm).toHaveBeenCalledOnce()
+  })
+
+  it('вызывает onCancel при клике «Отмена»', () => {
+    const onCancel = vi.fn()
+    render(<ConfirmDialog message="Удалить?" onConfirm={vi.fn()} onCancel={onCancel} />)
+    fireEvent.click(screen.getByRole('button', { name: /отмена/i }))
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+})

--- a/src/tests/ErrorBoundary.test.jsx
+++ b/src/tests/ErrorBoundary.test.jsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import ErrorBoundary from '../components/ErrorBoundary'
+
+function Bomb() {
+  throw new Error('test crash')
+}
+
+// Suppress console.error for expected boundary errors
+const originalError = console.error
+beforeEach(() => { console.error = vi.fn() })
+afterEach(() => { console.error = originalError })
+
+describe('ErrorBoundary', () => {
+  it('рендерит дочерние элементы без ошибок', () => {
+    render(<ErrorBoundary><p>Содержимое</p></ErrorBoundary>)
+    expect(screen.getByText('Содержимое')).toBeDefined()
+  })
+
+  it('показывает fallback при крэше дочернего компонента', () => {
+    render(<ErrorBoundary><Bomb /></ErrorBoundary>)
+    expect(screen.getByText(/что-то пошло не так/i)).toBeDefined()
+  })
+
+  it('показывает кнопку «Перезагрузить»', () => {
+    render(<ErrorBoundary><Bomb /></ErrorBoundary>)
+    expect(screen.getByRole('button', { name: /перезагрузить/i })).toBeDefined()
+  })
+})

--- a/src/tests/OrdersPage.test.jsx
+++ b/src/tests/OrdersPage.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import OrdersPage from '../pages/OrdersPage'
 import OrderCard from '../components/OrderCard'
 
@@ -39,26 +39,26 @@ describe('OrdersPage', () => {
   beforeEach(() => vi.clearAllMocks())
 
   it('показывает загрузку', () => {
-    useOrders.mockReturnValue({ orders: [], loading: true, error: null, refresh: vi.fn() })
+    useOrders.mockReturnValue({ orders: [], loading: true, error: null, refresh: vi.fn(), deleteOrder: vi.fn() })
     render(<OrdersPage />)
     expect(screen.getByText(/загрузка/i)).toBeDefined()
   })
 
   it('показывает ошибку с кнопкой повторить', () => {
-    useOrders.mockReturnValue({ orders: [], loading: false, error: 'Нет сети', refresh: vi.fn() })
+    useOrders.mockReturnValue({ orders: [], loading: false, error: 'Нет сети', refresh: vi.fn(), deleteOrder: vi.fn() })
     render(<OrdersPage />)
-    expect(screen.getByText('Нет сети')).toBeDefined()
+    expect(screen.getByText(/не удалось загрузить заказы/i)).toBeDefined()
     expect(screen.getByText(/повторить/i)).toBeDefined()
   })
 
   it('показывает сообщение при пустом списке', () => {
-    useOrders.mockReturnValue({ orders: [], loading: false, error: null, refresh: vi.fn() })
+    useOrders.mockReturnValue({ orders: [], loading: false, error: null, refresh: vi.fn(), deleteOrder: vi.fn() })
     render(<OrdersPage />)
     expect(screen.getByText(/активных заказов нет/i)).toBeDefined()
   })
 
   it('рендерит карточки заказов', () => {
-    useOrders.mockReturnValue({ orders: mockOrders, loading: false, error: null, refresh: vi.fn() })
+    useOrders.mockReturnValue({ orders: mockOrders, loading: false, error: null, refresh: vi.fn(), deleteOrder: vi.fn() })
     render(<OrdersPage />)
     expect(screen.getByText('Анна')).toBeDefined()
     expect(screen.getByText('Мария')).toBeDefined()
@@ -102,5 +102,37 @@ describe('OrderCard', () => {
   it('не показывает кнопку смены статуса без onStatusChange', () => {
     render(<OrderCard order={mockOrders[0]} />)
     expect(screen.queryByText(/→/)).toBeNull()
+  })
+
+  it('показывает кнопку «Отменить заказ» когда передан onDelete', () => {
+    render(<OrderCard order={mockOrders[0]} onDelete={vi.fn()} />)
+    expect(screen.getByText(/отменить заказ/i)).toBeDefined()
+  })
+
+  it('не показывает кнопку «Отменить заказ» без onDelete', () => {
+    render(<OrderCard order={mockOrders[0]} />)
+    expect(screen.queryByText(/отменить заказ/i)).toBeNull()
+  })
+
+  it('показывает диалог подтверждения при клике «Отменить заказ»', () => {
+    render(<OrderCard order={mockOrders[0]} onDelete={vi.fn()} />)
+    fireEvent.click(screen.getByText(/отменить заказ/i))
+    expect(screen.getByText(/удалить заказ/i)).toBeDefined()
+  })
+
+  it('вызывает onDelete после подтверждения', () => {
+    const onDelete = vi.fn()
+    render(<OrderCard order={mockOrders[0]} onDelete={onDelete} />)
+    fireEvent.click(screen.getByText(/отменить заказ/i))
+    fireEvent.click(screen.getByRole('button', { name: /^да$/i }))
+    expect(onDelete).toHaveBeenCalled()
+  })
+
+  it('не вызывает onDelete при отмене', () => {
+    const onDelete = vi.fn()
+    render(<OrderCard order={mockOrders[0]} onDelete={onDelete} />)
+    fireEvent.click(screen.getByText(/отменить заказ/i))
+    fireEvent.click(screen.getByRole('button', { name: /отмена/i }))
+    expect(onDelete).not.toHaveBeenCalled()
   })
 })

--- a/src/tests/SuppliersPage.test.jsx
+++ b/src/tests/SuppliersPage.test.jsx
@@ -43,7 +43,7 @@ describe('SuppliersPage', () => {
   it('показывает ошибку', () => {
     useSuppliers.mockReturnValue(defaultMock({ error: 'Нет сети' }))
     render(<SuppliersPage />)
-    expect(screen.getByText('Нет сети')).toBeDefined()
+    expect(screen.getByText(/не удалось загрузить поставщиков/i)).toBeDefined()
   })
 
   it('показывает сообщение при пустом списке', () => {
@@ -106,12 +106,31 @@ describe('SuppliersPage', () => {
     expect(screen.getByDisplayValue('Розы опт')).toBeDefined()
   })
 
-  it('вызывает deleteSupplier при клике «Удалить»', async () => {
+  it('показывает диалог подтверждения при клике «Удалить»', () => {
+    useSuppliers.mockReturnValue(defaultMock({ suppliers: mockSuppliers }))
+    render(<SuppliersPage />)
+    const deleteBtns = screen.getAllByText('Удалить')
+    fireEvent.click(deleteBtns[0])
+    expect(screen.getByText(/удалить поставщика/i)).toBeDefined()
+  })
+
+  it('вызывает deleteSupplier после подтверждения', async () => {
     const deleteSupplier = vi.fn().mockResolvedValue(undefined)
     useSuppliers.mockReturnValue(defaultMock({ suppliers: mockSuppliers, deleteSupplier }))
     render(<SuppliersPage />)
     const deleteBtns = screen.getAllByText('Удалить')
     fireEvent.click(deleteBtns[0])
+    fireEvent.click(screen.getByRole('button', { name: /^да$/i }))
     await waitFor(() => expect(deleteSupplier).toHaveBeenCalledWith('1'))
+  })
+
+  it('не вызывает deleteSupplier при отмене', async () => {
+    const deleteSupplier = vi.fn()
+    useSuppliers.mockReturnValue(defaultMock({ suppliers: mockSuppliers, deleteSupplier }))
+    render(<SuppliersPage />)
+    const deleteBtns = screen.getAllByText('Удалить')
+    fireEvent.click(deleteBtns[0])
+    fireEvent.click(screen.getByRole('button', { name: /отмена/i }))
+    expect(deleteSupplier).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
- ErrorBoundary: ловит JS-крэши, показывает «Что-то пошло не так» + кнопку перезагрузки
- ConfirmDialog: диалог «Да / Отмена» перед удалением поставщика и заказа
- useOnlineStatus: отслеживает navigator.onLine через события online/offline
- App.jsx: офлайн-баннер «Нет интернета — только просмотр» + ErrorBoundary вокруг <main>
- SuppliersPage: ConfirmDialog перед deleteSupplier; поле «Имя» — красная рамка + «Обязательное поле» при blur; сообщения ошибок без технических текстов
- OrderCard: кнопка «Отменить заказ» с ConfirmDialog (prop onDelete)
- useOrders: добавлен deleteOrder
- OrdersPage: wire up onDelete + обработка ошибки удаления; сообщение об ошибке загрузки без технического текста
- тесты: 13 файлов, 106 тестов — все зелёные